### PR TITLE
refactor: 将今日荐股模块移至页面最顶部

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -294,6 +294,10 @@ a:hover {
   white-space: nowrap;
 }
 
+.reco-section {
+  margin-bottom: 28px;
+}
+
 .reco-cards {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));

--- a/index.html
+++ b/index.html
@@ -23,6 +23,15 @@
       </div>
     </header>
 
+    <section class="panel panel--wide reco-section">
+      <div class="panel__head">
+        <h2>今日荐股</h2>
+        <p id="reco-strategy">趋势跟踪 + 动量评分策略，每 5 分钟自动更新</p>
+      </div>
+      <div class="reco-cards" id="reco-cards"></div>
+      <p class="reco-disclaimer" id="reco-disclaimer"></p>
+    </section>
+
     <section class="summary" id="summary-cards" aria-label="市场概览"></section>
 
     <main class="grid">
@@ -75,15 +84,6 @@
         <div class="chart-box chart-box--tall">
           <canvas id="stocks-chart" aria-label="个股走势对比图"></canvas>
         </div>
-      </section>
-
-      <section class="panel panel--wide">
-        <div class="panel__head">
-          <h2>今日荐股</h2>
-          <p id="reco-strategy">趋势跟踪 + 动量评分策略，每 5 分钟自动更新</p>
-        </div>
-        <div class="reco-cards" id="reco-cards"></div>
-        <p class="reco-disclaimer" id="reco-disclaimer"></p>
       </section>
 
       <section class="panel panel--wide">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

将「今日荐股」模块从页面中部移至 Header 下方、市场概览卡片之前，作为页面最优先展示的内容。

## 修改文件
- `index.html`：调整模块位置
- `css/styles.css`：为顶部荐股区域增加间距
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62fa50dd-4422-4777-aa97-3de214aa93a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62fa50dd-4422-4777-aa97-3de214aa93a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

