### PR TITLE
feat: 优化荐股策略，覆盖 A股/港股/美股三市场

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -298,6 +298,40 @@ a:hover {
   margin-bottom: 28px;
 }
 
+.reco-scan {
+  grid-column: 1 / -1;
+  margin: 0 0 4px;
+  color: var(--text-muted);
+  font-size: 0.84rem;
+}
+
+.reco-card__tags {
+  margin-bottom: 6px;
+}
+
+.reco-market {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.reco-market--cn {
+  background: rgba(248, 113, 113, 0.16);
+  color: #f87171;
+}
+
+.reco-market--hk {
+  background: rgba(251, 191, 36, 0.16);
+  color: #fbbf24;
+}
+
+.reco-market--us {
+  background: rgba(56, 189, 248, 0.16);
+  color: #38bdf8;
+}
+
 .reco-cards {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));

--- a/data/market.json
+++ b/data/market.json
@@ -1,11 +1,11 @@
 {
-  "updatedAt": "2026-06-15T01:25:39+00:00",
+  "updatedAt": "2026-06-15T01:52:20+00:00",
   "summary": {
     "tracked": 6,
     "up": 6,
     "down": 0,
     "flat": 0,
-    "avgChangePct": 1.62,
+    "avgChangePct": 1.4,
     "mood": "偏多"
   },
   "indices": [
@@ -153,13 +153,12 @@
       "region": "香港",
       "sector": null,
       "currency": "HKD",
-      "price": 24718.1,
-      "change": 468.81,
-      "changePct": 1.93,
-      "weekChangePct": -0.98,
-      "monthChangePct": -6.33,
+      "price": 25015.37,
+      "change": 297.27,
+      "changePct": 1.2,
+      "weekChangePct": 1.45,
+      "monthChangePct": -5.21,
       "sparkline": [
-        25776.53,
         26095.88,
         25898.61,
         26213.78,
@@ -188,10 +187,11 @@
         24565.9,
         24407.96,
         24249.29,
-        24718.1
+        24718.1,
+        25015.37
       ],
       "marketCap": null,
-      "volume": 3751900000
+      "volume": 0
     },
     {
       "symbol": "^N225",
@@ -199,11 +199,11 @@
       "region": "日本",
       "sector": null,
       "currency": "JPY",
-      "price": 69414.38,
-      "change": 3394.34,
-      "changePct": 5.14,
-      "weekChangePct": 8.42,
-      "monthChangePct": 13.04,
+      "price": 69374.71,
+      "change": 3354.67,
+      "changePct": 5.08,
+      "weekChangePct": 8.36,
+      "monthChangePct": 12.97,
       "sparkline": [
         59284.92,
         59513.12,
@@ -234,7 +234,7 @@
         64179.27,
         64217.27,
         66020.04,
-        69414.38
+        69374.71
       ],
       "marketCap": null,
       "volume": 0
@@ -245,13 +245,12 @@
       "region": "中国",
       "sector": null,
       "currency": "CNY",
-      "price": 4031.51,
-      "change": 44.5,
-      "changePct": 1.12,
-      "weekChangePct": 0.09,
-      "monthChangePct": -3.5,
+      "price": 4056.95,
+      "change": 25.44,
+      "changePct": 0.63,
+      "weekChangePct": 2.47,
+      "monthChangePct": -1.9,
       "sparkline": [
-        4107.51,
         4112.16,
         4160.17,
         4180.09,
@@ -280,10 +279,11 @@
         4010.03,
         3993.23,
         3987.01,
-        4031.51
+        4031.51,
+        4056.95
       ],
       "marketCap": null,
-      "volume": 743100
+      "volume": 1283947908
     }
   ],
   "stocks": [
@@ -293,11 +293,11 @@
       "region": null,
       "sector": "消费电子",
       "currency": "HKD",
-      "price": 26.26,
-      "change": 0.06,
-      "changePct": 0.23,
-      "weekChangePct": -4.09,
-      "monthChangePct": -17.21,
+      "price": 26.7,
+      "change": 0.5,
+      "changePct": 1.91,
+      "weekChangePct": -2.48,
+      "monthChangePct": -15.83,
       "sparkline": [
         30.98,
         30.46,
@@ -328,10 +328,10 @@
         26.32,
         25.84,
         26.2,
-        26.26
+        26.7
       ],
-      "marketCap": 676478327504.6167,
-      "volume": 131880583
+      "marketCap": 687813088463.7223,
+      "volume": 17974681
     },
     {
       "symbol": "9992.HK",
@@ -339,11 +339,11 @@
       "region": null,
       "sector": "潮玩零售",
       "currency": "HKD",
-      "price": 183.0,
-      "change": 0.0,
-      "changePct": 0.0,
-      "weekChangePct": 7.33,
-      "monthChangePct": 19.0,
+      "price": 183.1,
+      "change": 0.1,
+      "changePct": 0.05,
+      "weekChangePct": 7.39,
+      "monthChangePct": 19.07,
       "sparkline": [
         152.99,
         156.43,
@@ -374,10 +374,10 @@
         173.1,
         178.3,
         183.0,
-        183.0
+        183.1
       ],
-      "marketCap": 241696042932.0,
-      "volume": 20417954
+      "marketCap": 241828125333.578,
+      "volume": 1617058
     },
     {
       "symbol": "000660.KS",
@@ -385,11 +385,11 @@
       "region": null,
       "sector": "半导体",
       "currency": "KRW",
-      "price": 2312000.0,
-      "change": 162000.0,
-      "changePct": 7.53,
-      "weekChangePct": 20.98,
-      "monthChangePct": 17.02,
+      "price": 2296000.0,
+      "change": 146000.0,
+      "changePct": 6.79,
+      "weekChangePct": 20.15,
+      "monthChangePct": 16.21,
       "sparkline": [
         1292783.88,
         1285785.0,
@@ -420,87 +420,97 @@
         2048000.0,
         2101000.0,
         2150000.0,
-        2312000.0
+        2296000.0
       ],
-      "marketCap": 1640474653101000.0,
-      "volume": 1254654
+      "marketCap": 1629826829736000.0,
+      "volume": 1476199
     }
   ],
   "news": [],
   "recommendations": {
-    "strategy": "趋势跟踪 + 动量评分：均线多头排列（40 分）、1/3 月动量（30 分）、RSI 健康度（20 分）、量能（10 分）；得分 ≥70 给出买入信号，≥55 列入观察。止损按 2 倍 ATR，目标盈亏比 1:2。",
-    "disclaimer": "量化信号仅供参考，不构成投资建议。股市有风险，请严格执行止损纪律。",
+    "strategy": "多因子趋势策略（A股/港股/美股各选1只）：趋势结构25分、动量20分、相对强弱15分、RSI15分、MACD10分、量能10分、市场环境5分；≥72买入，≥58观察。止损按ATR动态调整，盈亏比1:2.5。",
+    "marketScan": "A股最高 中国平安(63.5分) · 港股最高 泡泡玛特(65.0分) · 美股最高 AMD(80.0分)",
+    "disclaimer": "量化信号仅供参考，不构成投资建议。请分散配置三市场、严格执行止损。",
     "picks": [
       {
         "symbol": "AMD",
         "name": "AMD",
+        "market": "美股",
         "sector": "半导体",
         "currency": "USD",
         "price": 511.57,
-        "score": 90.0,
+        "score": 80.0,
         "signal": "buy",
         "signalLabel": "建议买入",
         "rsi": 60.5,
         "monthChangePct": 14.83,
+        "relativeStrength": 14.42,
         "reasons": [
           "价格站上 20 日均线",
           "价格站上 60 日均线",
-          "均线多头排列（20日 > 60日）",
-          "近 1 月上涨 14.8%"
+          "均线多头排列（10日 > 20日 > 60日）",
+          "近 1 月上涨 14.8%",
+          "近 3 月上涨 160.2%"
         ],
         "plan": {
-          "entry": "现价 511.57 附近分批买入，或回踩 20 日均线 481.97 时加仓",
-          "stopLoss": "跌破 441.45（约 -13.7%，2 倍 ATR）坚决止损",
-          "target": "目标价 651.80（盈亏比 1:2），到达后可分批止盈",
-          "position": "建议仓位不超过总资金 14.6%（单笔风险控制在 2.0% 以内）"
-        }
-      },
-      {
-        "symbol": "000660.KS",
-        "name": "SK 海力士",
-        "sector": "半导体",
-        "currency": "KRW",
-        "price": 2312000.0,
-        "score": 90.0,
-        "signal": "buy",
-        "signalLabel": "建议买入",
-        "rsi": 63.2,
-        "monthChangePct": 17.02,
-        "reasons": [
-          "价格站上 20 日均线",
-          "价格站上 60 日均线",
-          "均线多头排列（20日 > 60日）",
-          "近 1 月上涨 17.0%"
-        ],
-        "plan": {
-          "entry": "现价 2312000.00 附近分批买入，或回踩 20 日均线 2088621.89 时加仓",
-          "stopLoss": "跌破 1939867.94（约 -16.1%，2 倍 ATR）坚决止损",
-          "target": "目标价 3056264.12（盈亏比 1:2），到达后可分批止盈",
-          "position": "建议仓位不超过总资金 12.4%（单笔风险控制在 2.0% 以内）"
+          "entry": "现价 511.57 轻仓试探；回踩 20 日均线 481.97 或 472.33 附近分批加仓",
+          "stopLoss": "跌破 458.98（约 -10.3%，1.5 倍 ATR）坚决止损",
+          "target": "第一目标 643.04（盈亏比 1:2.5），可分批止盈",
+          "position": "美股标的建议仓位 ≤ 总资金 19.4%（单笔风险 2.0%）；三市场分散配置"
         }
       },
       {
         "symbol": "9992.HK",
         "name": "泡泡玛特",
+        "market": "港股",
         "sector": "潮玩零售",
         "currency": "HKD",
-        "price": 183.0,
+        "price": 183.2,
         "score": 65.0,
         "signal": "watch",
         "signalLabel": "建议观察",
-        "rsi": 66.4,
-        "monthChangePct": 19.0,
+        "rsi": 66.6,
+        "monthChangePct": 19.13,
+        "relativeStrength": 24.34,
         "reasons": [
           "价格站上 20 日均线",
           "价格站上 60 日均线",
-          "均线多头排列（20日 > 60日）",
-          "近 1 月上涨 19.0%"
+          "均线多头排列（10日 > 20日 > 60日）",
+          "近 1 月上涨 19.1%",
+          "近 1 月跑赢港股基准 24.3%"
         ],
         "plan": {
-          "entry": "现价 183.00 附近分批买入，或回踩 20 日均线 167.33 时加仓",
-          "stopLoss": "跌破 164.73（约 -10.0%，2 倍 ATR）坚决止损",
-          "target": "目标价 219.54（盈亏比 1:2），到达后可分批止盈",
-          "position": "建议仓位不超过总资金 20.0%（单笔风险控制在 2.0% 以内）"
+          "entry": "现价 183.20 轻仓试探；回踩 20 日均线 167.34 或 163.99 附近分批加仓",
+          "stopLoss": "跌破 165.64（约 -9.6%，2.0 倍 ATR）坚决止损",
+          "target": "第一目标 227.09（盈亏比 1:2.5），可分批止盈",
+          "position": "港股标的建议仓位 ≤ 总资金 20.8%（单笔风险 2.0%）；三市场分散配置"
+        }
+      },
+      {
+        "symbol": "601318.SS",
+        "name": "中国平安",
+        "market": "A股",
+        "sector": "保险",
+        "currency": "CNY",
+        "price": 55.27,
+        "score": 63.5,
+        "signal": "watch",
+        "signalLabel": "建议观察",
+        "rsi": 61.0,
+        "monthChangePct": 2.93,
+        "relativeStrength": 5.83,
+        "reasons": [
+          "价格站上 20 日均线",
+          "价格站上 60 日均线",
+          "近 1 月上涨 2.9%",
+          "近 1 月跑赢A股基准 5.8%",
+          "RSI 61.0 趋势健康区"
+        ],
+        "plan": {
+          "entry": "现价 55.27 轻仓试探；回踩 20 日均线 52.33 或 51.29 附近分批加仓",
+          "stopLoss": "跌破 52.79（约 -4.5%，2.0 倍 ATR）坚决止损",
+          "target": "第一目标 61.47（盈亏比 1:2.5），可分批止盈",
+          "position": "A股标的建议仓位 ≤ 总资金 25%（单笔风险 2.0%）；三市场分散配置"
         }
       }
     ]

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     <section class="panel panel--wide reco-section">
       <div class="panel__head">
         <h2>今日荐股</h2>
-        <p id="reco-strategy">趋势跟踪 + 动量评分策略，每 5 分钟自动更新</p>
+        <p id="reco-strategy">多因子趋势策略 · A股 / 港股 / 美股 各选 1 只</p>
       </div>
       <div class="reco-cards" id="reco-cards"></div>
       <p class="reco-disclaimer" id="reco-disclaimer"></p>

--- a/js/app.js
+++ b/js/app.js
@@ -182,12 +182,19 @@ function renderRecommendations(reco) {
   if (strategyEl && reco.strategy) strategyEl.textContent = reco.strategy;
   if (disclaimerEl && reco.disclaimer) disclaimerEl.textContent = reco.disclaimer;
 
-  container.innerHTML = reco.picks
+  const scanHtml = reco.marketScan
+    ? `<p class="reco-scan">${reco.marketScan}</p>`
+    : "";
+
+  container.innerHTML = scanHtml + reco.picks
     .map(
       (pick) => `
         <article class="reco-card reco-card--${pick.signal}">
           <div class="reco-card__top">
             <div>
+              <div class="reco-card__tags">
+                <span class="reco-market reco-market--${pick.market === "A股" ? "cn" : pick.market === "港股" ? "hk" : "us"}">${pick.market || ""}</span>
+              </div>
               <h3>${pick.name}</h3>
               <p class="stock-card__symbol">${pick.symbol} · ${pick.sector || ""}</p>
             </div>

--- a/scripts/fetch_data.py
+++ b/scripts/fetch_data.py
@@ -30,30 +30,46 @@ STOCKS = {
 
 NEWS_TICKERS = ["^GSPC", "1810.HK", "9992.HK", "000660.KS"]
 
-# 荐股候选池：流动性好的大盘股，覆盖美股科技与港股核心资产
+# 荐股候选池：按市场分组，覆盖 A 股 / 港股 / 美股
 CANDIDATES = {
-    "AAPL": {"name": "苹果", "sector": "消费电子", "currency": "USD"},
-    "MSFT": {"name": "微软", "sector": "软件云计算", "currency": "USD"},
-    "NVDA": {"name": "英伟达", "sector": "半导体", "currency": "USD"},
-    "GOOGL": {"name": "谷歌", "sector": "互联网", "currency": "USD"},
-    "AMZN": {"name": "亚马逊", "sector": "电商云计算", "currency": "USD"},
-    "META": {"name": "Meta", "sector": "社交广告", "currency": "USD"},
-    "TSLA": {"name": "特斯拉", "sector": "新能源车", "currency": "USD"},
-    "AMD": {"name": "AMD", "sector": "半导体", "currency": "USD"},
-    "0700.HK": {"name": "腾讯控股", "sector": "互联网", "currency": "HKD"},
-    "9988.HK": {"name": "阿里巴巴", "sector": "电商云计算", "currency": "HKD"},
-    "3690.HK": {"name": "美团", "sector": "本地生活", "currency": "HKD"},
-    "1810.HK": {"name": "小米集团", "sector": "消费电子", "currency": "HKD"},
-    "9992.HK": {"name": "泡泡玛特", "sector": "潮玩零售", "currency": "HKD"},
-    "000660.KS": {"name": "SK 海力士", "sector": "半导体", "currency": "KRW"},
+    # A 股
+    "600519.SS": {"name": "贵州茅台", "sector": "白酒", "currency": "CNY", "market": "A股"},
+    "300750.SZ": {"name": "宁德时代", "sector": "新能源", "currency": "CNY", "market": "A股"},
+    "601318.SS": {"name": "中国平安", "sector": "保险", "currency": "CNY", "market": "A股"},
+    "000858.SZ": {"name": "五粮液", "sector": "白酒", "currency": "CNY", "market": "A股"},
+    "688981.SS": {"name": "中芯国际", "sector": "半导体", "currency": "CNY", "market": "A股"},
+    "600036.SS": {"name": "招商银行", "sector": "银行", "currency": "CNY", "market": "A股"},
+    # 港股
+    "0700.HK": {"name": "腾讯控股", "sector": "互联网", "currency": "HKD", "market": "港股"},
+    "9988.HK": {"name": "阿里巴巴", "sector": "电商云计算", "currency": "HKD", "market": "港股"},
+    "3690.HK": {"name": "美团", "sector": "本地生活", "currency": "HKD", "market": "港股"},
+    "1810.HK": {"name": "小米集团", "sector": "消费电子", "currency": "HKD", "market": "港股"},
+    "9992.HK": {"name": "泡泡玛特", "sector": "潮玩零售", "currency": "HKD", "market": "港股"},
+    "9618.HK": {"name": "京东集团", "sector": "电商", "currency": "HKD", "market": "港股"},
+    # 美股
+    "AAPL": {"name": "苹果", "sector": "消费电子", "currency": "USD", "market": "美股"},
+    "MSFT": {"name": "微软", "sector": "软件云计算", "currency": "USD", "market": "美股"},
+    "NVDA": {"name": "英伟达", "sector": "半导体", "currency": "USD", "market": "美股"},
+    "GOOGL": {"name": "谷歌", "sector": "互联网", "currency": "USD", "market": "美股"},
+    "AMZN": {"name": "亚马逊", "sector": "电商云计算", "currency": "USD", "market": "美股"},
+    "META": {"name": "Meta", "sector": "社交广告", "currency": "USD", "market": "美股"},
+    "AMD": {"name": "AMD", "sector": "半导体", "currency": "USD", "market": "美股"},
+}
+
+# 各市场基准指数（用于相对强弱与市场环境判断）
+MARKET_BENCHMARKS = {
+    "A股": "000001.SS",
+    "港股": "^HSI",
+    "美股": "^GSPC",
 }
 
 # 策略参数
-RISK_PER_TRADE_PCT = 2.0   # 单笔交易最大亏损占总资金比例
-REWARD_RISK_RATIO = 2.0    # 目标盈亏比
-BUY_SCORE = 70             # 达到该分数给出买入信号
-WATCH_SCORE = 55           # 达到该分数列入观察
-MAX_PICKS = 3
+RISK_PER_TRADE_PCT = 2.0
+REWARD_RISK_RATIO = 2.5
+BUY_SCORE = 72
+WATCH_SCORE = 58
+MAX_PICKS_PER_MARKET = 1
+MARKETS = ("A股", "港股", "美股")
 
 
 def pct_change(current: float, previous: float) -> float | None:
@@ -190,15 +206,67 @@ def sma(values: list[float], period: int) -> float | None:
     return sum(values[-period:]) / period
 
 
-def analyze_candidate(symbol: str, meta: dict) -> dict | None:
-    """趋势跟踪 + 动量评分策略。
+def ema(values: list[float], period: int) -> list[float]:
+    if not values:
+        return []
+    k = 2 / (period + 1)
+    result = [values[0]]
+    for v in values[1:]:
+        result.append(v * k + result[-1] * (1 - k))
+    return result
 
-    评分维度（满分 100）：
-    - 趋势（40 分）：价格在 20 日 / 60 日均线上方，且短均线在长均线上方（多头排列）
-    - 动量（30 分）：1 月 / 3 月相对涨幅，奖励持续走强的标的
-    - RSI 健康度（20 分）：45-65 为理想趋势区，>75 视为超买扣分
-    - 量能（10 分）：近 5 日均量高于 20 日均量，代表资金关注
-    """
+
+def compute_macd(closes: list[float]) -> tuple[float | None, float | None, float | None]:
+    """返回 (MACD线, 信号线, 柱状图) 最新值。"""
+    if len(closes) < 35:
+        return None, None, None
+    ema12 = ema(closes, 12)
+    ema26 = ema(closes, 26)
+    macd_line = [a - b for a, b in zip(ema12, ema26)]
+    signal = ema(macd_line, 9)
+    hist = macd_line[-1] - signal[-1]
+    return round(macd_line[-1], 4), round(signal[-1], 4), round(hist, 4)
+
+
+def fetch_benchmark_closes() -> dict[str, list[float]]:
+    cache: dict[str, list[float]] = {}
+    for market, symbol in MARKET_BENCHMARKS.items():
+        try:
+            hist = yf.Ticker(symbol).history(period="6mo", interval="1d")
+            if not hist.empty:
+                cache[market] = [float(v) for v in hist["Close"].dropna().tolist()]
+        except Exception:
+            continue
+    return cache
+
+
+def benchmark_return(closes: list[float], days: int) -> float | None:
+    if len(closes) < days + 1:
+        return None
+    return pct_change(closes[-1], closes[-days - 1])
+
+
+def price_digits(price: float) -> int:
+    if price >= 1000:
+        return 2
+    if price >= 10:
+        return 2
+    return 3
+
+
+def analyze_candidate(symbol: str, meta: dict, benchmarks: dict[str, list[float]]) -> dict | None:
+    """多因子趋势策略（满分 100），覆盖 A 股 / 港股 / 美股。
+
+  评分维度：
+  - 趋势结构（25）：均线多头排列 + 价格结构
+  - 动量（20）：1 月 / 3 月涨幅
+  - 相对强弱（15）：跑赢所属市场基准指数
+  - RSI（15）：趋势健康区，避免超买追高
+  - MACD（10）：金叉或柱状图转正
+  - 量能（10）：资金流入确认
+  - 市场环境（5）：所属市场指数处于多头
+  """
+    market = meta.get("market", "美股")
     try:
         hist = yf.Ticker(symbol).history(period="6mo", interval="1d")
     except Exception:
@@ -214,56 +282,110 @@ def analyze_candidate(symbol: str, meta: dict) -> dict | None:
         return None
 
     price = closes[-1]
+    sma10 = sma(closes, 10)
     sma20 = sma(closes, 20)
     sma60 = sma(closes, 60)
     rsi = compute_rsi(closes)
     atr = compute_atr(highs, lows, closes)
+    macd, macd_signal, macd_hist = compute_macd(closes)
     month_chg = pct_change(price, closes[-22]) if len(closes) >= 22 else None
-    quarter_chg = pct_change(price, closes[0])
+    quarter_chg = pct_change(price, closes[-63]) if len(closes) >= 63 else pct_change(price, closes[0])
 
-    if not all(v is not None for v in (sma20, sma60, rsi, atr, month_chg, quarter_chg)):
+    bench = benchmarks.get(market, [])
+    bench_month = benchmark_return(bench, 22) if bench else None
+    rel_strength = round(month_chg - bench_month, 2) if month_chg is not None and bench_month is not None else None
+
+    if not all(v is not None for v in (sma20, sma60, rsi, atr, month_chg, quarter_chg, macd, macd_signal, macd_hist)):
         return None
 
     score = 0.0
     reasons: list[str] = []
 
-    # 趋势 40 分
+    # 趋势结构 25 分
     if price > sma20:
-        score += 15
+        score += 8
         reasons.append("价格站上 20 日均线")
     if price > sma60:
-        score += 10
+        score += 7
         reasons.append("价格站上 60 日均线")
-    if sma20 > sma60:
-        score += 15
-        reasons.append("均线多头排列（20日 > 60日）")
+    if sma10 and sma10 > sma20 > sma60:
+        score += 10
+        reasons.append("均线多头排列（10日 > 20日 > 60日）")
+    elif sma20 > sma60:
+        score += 5
+        reasons.append("中期均线多头排列")
 
-    # 动量 30 分
+    # 动量 20 分
     if month_chg > 0:
-        score += min(month_chg * 1.5, 15)
+        score += min(month_chg * 1.2, 10)
         reasons.append(f"近 1 月上涨 {month_chg:.1f}%")
     if quarter_chg > 0:
-        score += min(quarter_chg * 0.5, 15)
+        score += min(quarter_chg * 0.4, 10)
         reasons.append(f"近 3 月上涨 {quarter_chg:.1f}%")
 
-    # RSI 健康度 20 分
-    if 45 <= rsi <= 65:
-        score += 20
-        reasons.append(f"RSI {rsi} 处于健康趋势区")
-    elif 35 <= rsi < 45 or 65 < rsi <= 75:
+    # 相对强弱 15 分（跑赢所属市场才有超额收益潜力）
+    if rel_strength is not None:
+        if rel_strength > 5:
+            score += 15
+            reasons.append(f"近 1 月跑赢{market}基准 {rel_strength:.1f}%")
+        elif rel_strength > 0:
+            score += 10
+            reasons.append(f"近 1 月略强于{market}基准")
+        elif rel_strength > -3:
+            score += 4
+        else:
+            score -= 5
+            reasons.append(f"近 1 月弱于{market}基准 {rel_strength:.1f}%")
+
+    # RSI 15 分
+    if 48 <= rsi <= 62:
+        score += 15
+        reasons.append(f"RSI {rsi} 趋势健康区")
+    elif 40 <= rsi < 48:
         score += 10
-        reasons.append(f"RSI {rsi} 中性")
+        reasons.append(f"RSI {rsi} 偏低，关注反弹")
+    elif 62 < rsi <= 70:
+        score += 8
+        reasons.append(f"RSI {rsi} 偏强")
     elif rsi > 75:
-        score -= 10
-        reasons.append(f"RSI {rsi} 超买，注意追高风险")
+        score -= 12
+        reasons.append(f"RSI {rsi} 超买，不宜追高")
+    else:
+        score += 3
+
+    # MACD 10 分
+    if macd > macd_signal and macd_hist > 0:
+        score += 10
+        reasons.append("MACD 金叉且柱状图转正")
+    elif macd_hist > 0:
+        score += 6
+        reasons.append("MACD 动能回升")
+    elif macd > macd_signal:
+        score += 4
 
     # 量能 10 分
     vol5, vol20 = sma(volumes, 5), sma(volumes, 20)
-    if vol5 and vol20 and vol5 > vol20:
-        score += 10
-        reasons.append("近期成交量放大，资金关注度提升")
+    if vol5 and vol20:
+        vol_ratio = vol5 / vol20
+        if vol_ratio > 1.3:
+            score += 10
+            reasons.append("成交量显著放大")
+        elif vol_ratio > 1.05:
+            score += 6
+            reasons.append("成交量温和放大")
 
-    score = round(max(score, 0), 1)
+    # 市场环境 5 分
+    if bench and len(bench) >= 60:
+        bench_price = bench[-1]
+        bench_sma60 = sma(bench, 60)
+        if bench_sma60 and bench_price > bench_sma60:
+            score += 5
+            reasons.append(f"{market}大盘处于中期上升趋势")
+        elif bench_sma60 and bench_price < bench_sma60:
+            score -= 3
+            reasons.append(f"{market}大盘偏弱，注意系统性风险")
+
+    score = round(max(min(score, 100), 0), 1)
 
     if score >= BUY_SCORE:
         signal, signal_label = "buy", "建议买入"
@@ -272,23 +394,32 @@ def analyze_candidate(symbol: str, meta: dict) -> dict | None:
     else:
         signal, signal_label = "hold", "暂不参与"
 
-    # 操作计划：ATR 止损 + 固定盈亏比目标 + 风险敞口决定仓位
-    stop_loss = round(price - 2 * atr, 2)
-    target = round(price + 2 * atr * REWARD_RISK_RATIO, 2)
+    # 动态止损：趋势强用 1.5 倍 ATR，一般趋势 2 倍 ATR
+    atr_mult = 1.5 if score >= BUY_SCORE and sma10 and sma10 > sma20 > sma60 else 2.0
+    stop_loss = round(price - atr_mult * atr, 2)
+    target = round(price + atr_mult * atr * REWARD_RISK_RATIO, 2)
     stop_pct = round((price - stop_loss) / price * 100, 1)
-    position_pct = round(min(RISK_PER_TRADE_PCT / stop_pct * 100, 30), 1) if stop_pct > 0 else 0
+    position_pct = round(min(RISK_PER_TRADE_PCT / stop_pct * 100, 25), 1) if stop_pct > 0 else 0
 
-    digits = 2 if price >= 10 else 3
+    digits = price_digits(price)
+    pullback_zone = round(sma20 * 0.98, digits)
     plan = {
-        "entry": f"现价 {price:.{digits}f} 附近分批买入，或回踩 20 日均线 {sma20:.{digits}f} 时加仓",
-        "stopLoss": f"跌破 {stop_loss:.{digits}f}（约 -{stop_pct}%，2 倍 ATR）坚决止损",
-        "target": f"目标价 {target:.{digits}f}（盈亏比 1:{REWARD_RISK_RATIO:.0f}），到达后可分批止盈",
-        "position": f"建议仓位不超过总资金 {position_pct}%（单笔风险控制在 {RISK_PER_TRADE_PCT}% 以内）",
+        "entry": (
+            f"现价 {price:.{digits}f} 轻仓试探；回踩 20 日均线 {sma20:.{digits}f} "
+            f"或 {pullback_zone:.{digits}f} 附近分批加仓"
+        ),
+        "stopLoss": f"跌破 {stop_loss:.{digits}f}（约 -{stop_pct}%，{atr_mult:.1f} 倍 ATR）坚决止损",
+        "target": f"第一目标 {target:.{digits}f}（盈亏比 1:{REWARD_RISK_RATIO:.1f}），可分批止盈",
+        "position": (
+            f"{market}标的建议仓位 ≤ 总资金 {position_pct}%"
+            f"（单笔风险 {RISK_PER_TRADE_PCT}%）；三市场分散配置"
+        ),
     }
 
     return {
         "symbol": symbol,
         "name": meta["name"],
+        "market": market,
         "sector": meta.get("sector"),
         "currency": meta.get("currency", "USD"),
         "price": round(price, 2),
@@ -297,26 +428,58 @@ def analyze_candidate(symbol: str, meta: dict) -> dict | None:
         "signalLabel": signal_label,
         "rsi": rsi,
         "monthChangePct": month_chg,
-        "reasons": reasons[:4],
+        "relativeStrength": rel_strength,
+        "reasons": reasons[:5],
         "plan": plan,
     }
 
 
 def build_recommendations() -> dict:
+    benchmarks = fetch_benchmark_closes()
     analyzed = []
     for symbol, meta in CANDIDATES.items():
-        result = analyze_candidate(symbol, meta)
+        result = analyze_candidate(symbol, meta, benchmarks)
         if result:
             analyzed.append(result)
 
-    analyzed.sort(key=lambda x: x["score"], reverse=True)
-    picks = [a for a in analyzed if a["signal"] in ("buy", "watch")][:MAX_PICKS]
+    # 每个市场各选评分最高且达观察门槛的 1 只，确保 A 股 / 港股 / 美股全覆盖
+    picks: list[dict] = []
+    for market in MARKETS:
+        market_pool = [a for a in analyzed if a["market"] == market and a["signal"] in ("buy", "watch")]
+        market_pool.sort(key=lambda x: x["score"], reverse=True)
+        if market_pool:
+            picks.append(market_pool[0])
+        else:
+            # 该市场无达标标的时，展示最高分供参考（标记为观察）
+            fallback = sorted(
+                [a for a in analyzed if a["market"] == market],
+                key=lambda x: x["score"],
+                reverse=True,
+            )
+            if fallback and fallback[0]["score"] >= 45:
+                top = fallback[0].copy()
+                top["signal"] = "watch"
+                top["signalLabel"] = "弱信号观察"
+                picks.append(top)
+
+    picks.sort(key=lambda x: (0 if x["signal"] == "buy" else 1, -x["score"]))
+
+    market_summary = []
+    for market in MARKETS:
+        pool = [a for a in analyzed if a["market"] == market]
+        if pool:
+            best = max(pool, key=lambda x: x["score"])
+            market_summary.append(f"{market}最高 {best['name']}({best['score']}分)")
 
     return {
-        "strategy": "趋势跟踪 + 动量评分：均线多头排列（40 分）、1/3 月动量（30 分）、RSI 健康度（20 分）、量能（10 分）；"
-        f"得分 ≥{BUY_SCORE} 给出买入信号，≥{WATCH_SCORE} 列入观察。止损按 2 倍 ATR，目标盈亏比 1:{REWARD_RISK_RATIO:.0f}。",
-        "disclaimer": "量化信号仅供参考，不构成投资建议。股市有风险，请严格执行止损纪律。",
-        "picks": picks,
+        "strategy": (
+            "多因子趋势策略（A股/港股/美股各选1只）：趋势结构25分、动量20分、"
+            f"相对强弱15分、RSI15分、MACD10分、量能10分、市场环境5分；"
+            f"≥{BUY_SCORE}买入，≥{WATCH_SCORE}观察。止损按ATR动态调整，盈亏比1:{REWARD_RISK_RATIO}。"
+        ),
+        "marketScan": " · ".join(market_summary),
+        "disclaimer": "量化信号仅供参考，不构成投资建议。请分散配置三市场、严格执行止损。",
+        "picks": picks[: len(MARKETS)],
     }
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

全面升级荐股策略，确保 **A股 / 港股 / 美股** 三市场全覆盖。

### 策略升级（满分 100）
| 维度 | 分值 | 说明 |
|------|------|------|
| 趋势结构 | 25 | 10/20/60 日均线多头排列 |
| 动量 | 20 | 1 月 / 3 月涨幅 |
| 相对强弱 | 15 | 跑赢所属市场基准（上证/恒生/标普） |
| RSI | 15 | 趋势健康区，超买扣分 |
| MACD | 10 | 金叉 / 柱状图转正 |
| 量能 | 10 | 成交量放大确认 |
| 市场环境 | 5 | 所属大盘处于上升趋势 |

### 选股规则
- 候选池：A股 6 只 + 港股 6 只 + 美股 7 只
- **每个市场各选 1 只**，共 3 只推荐
- 动态 ATR 止损，盈亏比 1:2.5

### 前端
- 展示市场标签（A股/港股/美股）
- 展示三市场扫描摘要
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62fa50dd-4422-4777-aa97-3de214aa93a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62fa50dd-4422-4777-aa97-3de214aa93a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

