### PR TITLE
feat: 策略参数网格搜索与实验室/复盘增强

### DIFF
--- a/.github/workflows/weekly-backtest.yml
+++ b/.github/workflows/weekly-backtest.yml
@@ -27,11 +27,14 @@ jobs:
       - name: Run backtest
         run: python scripts/backtest.py
 
+      - name: Run parameter sweep
+        run: python scripts/optimize_params.py
+
       - name: Commit and push if changed
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/backtest.json
+          git add data/backtest.json data/param_sweep.json
           if git diff --staged --quiet; then
             echo "No backtest changes."
           else

--- a/css/styles.css
+++ b/css/styles.css
@@ -1061,6 +1061,86 @@ a:hover {
   color: var(--text-muted);
 }
 
+.panel--inline {
+  margin-bottom: 20px;
+}
+
+.param-sweep__recommendation {
+  margin: 0 0 14px;
+  padding: 10px 14px;
+  background: rgba(56, 189, 248, 0.08);
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 0.9rem;
+}
+
+.param-sweep-table .param-tag,
+.strategy-version .param-tag {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  vertical-align: middle;
+}
+
+.param-tag--current {
+  background: rgba(56, 189, 248, 0.15);
+  color: #38bdf8;
+}
+
+.param-tag--best {
+  background: rgba(52, 211, 153, 0.15);
+  color: #34d399;
+}
+
+.param-sweep-row--best {
+  background: rgba(52, 211, 153, 0.05);
+}
+
+.strategy-versions {
+  display: grid;
+  gap: 10px;
+}
+
+.strategy-version {
+  padding: 12px 14px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.strategy-version--current {
+  border-color: rgba(56, 189, 248, 0.4);
+}
+
+.strategy-version__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.strategy-version__date {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+.strategy-version__name {
+  margin: 6px 0 4px;
+  color: var(--text);
+  font-size: 0.9rem;
+}
+
+.strategy-version__params {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
 .market-metrics {
   margin-top: 16px;
   padding-top: 16px;

--- a/data/param_sweep.json
+++ b/data/param_sweep.json
@@ -1,0 +1,311 @@
+{
+  "updatedAt": "2026-06-15T07:12:01+00:00",
+  "strategyVersion": "v1.1.0",
+  "period": "1y",
+  "grid": {
+    "buyScore": [
+      72,
+      74,
+      76,
+      78,
+      80
+    ],
+    "watchScore": [
+      56,
+      58,
+      60,
+      62,
+      64
+    ]
+  },
+  "minTrades": 8,
+  "current": {
+    "buyScore": 78,
+    "watchScore": 62,
+    "totalTrades": 14,
+    "winRate": 42.9,
+    "expectancy": 0.25,
+    "profitFactor": 1.1,
+    "maxDrawdown": -20.6,
+    "sharpe": 0.15,
+    "annualReturn": 1.58
+  },
+  "best": {
+    "buyScore": 74,
+    "watchScore": 56,
+    "totalTrades": 15,
+    "winRate": 46.7,
+    "expectancy": 0.73,
+    "profitFactor": 1.32,
+    "maxDrawdown": -12.47,
+    "sharpe": 0.43,
+    "annualReturn": 9.14
+  },
+  "recommendation": "建议考虑 BUY_SCORE=74、WATCH_SCORE=56 （期望 0.73% vs 当前 0.25%）。",
+  "results": [
+    {
+      "buyScore": 74,
+      "watchScore": 56,
+      "totalTrades": 15,
+      "winRate": 46.7,
+      "expectancy": 0.73,
+      "profitFactor": 1.32,
+      "maxDrawdown": -12.47,
+      "sharpe": 0.43,
+      "annualReturn": 9.14
+    },
+    {
+      "buyScore": 74,
+      "watchScore": 58,
+      "totalTrades": 15,
+      "winRate": 46.7,
+      "expectancy": 0.73,
+      "profitFactor": 1.32,
+      "maxDrawdown": -12.47,
+      "sharpe": 0.43,
+      "annualReturn": 9.14
+    },
+    {
+      "buyScore": 74,
+      "watchScore": 60,
+      "totalTrades": 15,
+      "winRate": 46.7,
+      "expectancy": 0.73,
+      "profitFactor": 1.32,
+      "maxDrawdown": -12.47,
+      "sharpe": 0.43,
+      "annualReturn": 9.14
+    },
+    {
+      "buyScore": 74,
+      "watchScore": 62,
+      "totalTrades": 15,
+      "winRate": 46.7,
+      "expectancy": 0.73,
+      "profitFactor": 1.32,
+      "maxDrawdown": -12.47,
+      "sharpe": 0.43,
+      "annualReturn": 9.14
+    },
+    {
+      "buyScore": 74,
+      "watchScore": 64,
+      "totalTrades": 15,
+      "winRate": 46.7,
+      "expectancy": 0.73,
+      "profitFactor": 1.32,
+      "maxDrawdown": -12.47,
+      "sharpe": 0.43,
+      "annualReturn": 9.14
+    },
+    {
+      "buyScore": 76,
+      "watchScore": 56,
+      "totalTrades": 15,
+      "winRate": 46.7,
+      "expectancy": 0.73,
+      "profitFactor": 1.32,
+      "maxDrawdown": -12.47,
+      "sharpe": 0.43,
+      "annualReturn": 9.14
+    },
+    {
+      "buyScore": 76,
+      "watchScore": 58,
+      "totalTrades": 15,
+      "winRate": 46.7,
+      "expectancy": 0.73,
+      "profitFactor": 1.32,
+      "maxDrawdown": -12.47,
+      "sharpe": 0.43,
+      "annualReturn": 9.14
+    },
+    {
+      "buyScore": 76,
+      "watchScore": 60,
+      "totalTrades": 15,
+      "winRate": 46.7,
+      "expectancy": 0.73,
+      "profitFactor": 1.32,
+      "maxDrawdown": -12.47,
+      "sharpe": 0.43,
+      "annualReturn": 9.14
+    },
+    {
+      "buyScore": 76,
+      "watchScore": 62,
+      "totalTrades": 15,
+      "winRate": 46.7,
+      "expectancy": 0.73,
+      "profitFactor": 1.32,
+      "maxDrawdown": -12.47,
+      "sharpe": 0.43,
+      "annualReturn": 9.14
+    },
+    {
+      "buyScore": 76,
+      "watchScore": 64,
+      "totalTrades": 15,
+      "winRate": 46.7,
+      "expectancy": 0.73,
+      "profitFactor": 1.32,
+      "maxDrawdown": -12.47,
+      "sharpe": 0.43,
+      "annualReturn": 9.14
+    },
+    {
+      "buyScore": 78,
+      "watchScore": 56,
+      "totalTrades": 14,
+      "winRate": 42.9,
+      "expectancy": 0.25,
+      "profitFactor": 1.1,
+      "maxDrawdown": -20.6,
+      "sharpe": 0.15,
+      "annualReturn": 1.58
+    },
+    {
+      "buyScore": 78,
+      "watchScore": 58,
+      "totalTrades": 14,
+      "winRate": 42.9,
+      "expectancy": 0.25,
+      "profitFactor": 1.1,
+      "maxDrawdown": -20.6,
+      "sharpe": 0.15,
+      "annualReturn": 1.58
+    },
+    {
+      "buyScore": 78,
+      "watchScore": 60,
+      "totalTrades": 14,
+      "winRate": 42.9,
+      "expectancy": 0.25,
+      "profitFactor": 1.1,
+      "maxDrawdown": -20.6,
+      "sharpe": 0.15,
+      "annualReturn": 1.58
+    },
+    {
+      "buyScore": 78,
+      "watchScore": 62,
+      "totalTrades": 14,
+      "winRate": 42.9,
+      "expectancy": 0.25,
+      "profitFactor": 1.1,
+      "maxDrawdown": -20.6,
+      "sharpe": 0.15,
+      "annualReturn": 1.58
+    },
+    {
+      "buyScore": 78,
+      "watchScore": 64,
+      "totalTrades": 14,
+      "winRate": 42.9,
+      "expectancy": 0.25,
+      "profitFactor": 1.1,
+      "maxDrawdown": -20.6,
+      "sharpe": 0.15,
+      "annualReturn": 1.58
+    },
+    {
+      "buyScore": 72,
+      "watchScore": 56,
+      "totalTrades": 17,
+      "winRate": 41.2,
+      "expectancy": 0.21,
+      "profitFactor": 1.09,
+      "maxDrawdown": -17.0,
+      "sharpe": 0.13,
+      "annualReturn": 1.2
+    },
+    {
+      "buyScore": 72,
+      "watchScore": 58,
+      "totalTrades": 17,
+      "winRate": 41.2,
+      "expectancy": 0.21,
+      "profitFactor": 1.09,
+      "maxDrawdown": -17.0,
+      "sharpe": 0.13,
+      "annualReturn": 1.2
+    },
+    {
+      "buyScore": 72,
+      "watchScore": 60,
+      "totalTrades": 17,
+      "winRate": 41.2,
+      "expectancy": 0.21,
+      "profitFactor": 1.09,
+      "maxDrawdown": -17.0,
+      "sharpe": 0.13,
+      "annualReturn": 1.2
+    },
+    {
+      "buyScore": 72,
+      "watchScore": 62,
+      "totalTrades": 17,
+      "winRate": 41.2,
+      "expectancy": 0.21,
+      "profitFactor": 1.09,
+      "maxDrawdown": -17.0,
+      "sharpe": 0.13,
+      "annualReturn": 1.2
+    },
+    {
+      "buyScore": 80,
+      "watchScore": 56,
+      "totalTrades": 10,
+      "winRate": 30.0,
+      "expectancy": -1.11,
+      "profitFactor": 0.63,
+      "maxDrawdown": -22.76,
+      "sharpe": -0.71,
+      "annualReturn": -11.7
+    },
+    {
+      "buyScore": 80,
+      "watchScore": 58,
+      "totalTrades": 10,
+      "winRate": 30.0,
+      "expectancy": -1.11,
+      "profitFactor": 0.63,
+      "maxDrawdown": -22.76,
+      "sharpe": -0.71,
+      "annualReturn": -11.7
+    },
+    {
+      "buyScore": 80,
+      "watchScore": 60,
+      "totalTrades": 10,
+      "winRate": 30.0,
+      "expectancy": -1.11,
+      "profitFactor": 0.63,
+      "maxDrawdown": -22.76,
+      "sharpe": -0.71,
+      "annualReturn": -11.7
+    },
+    {
+      "buyScore": 80,
+      "watchScore": 62,
+      "totalTrades": 10,
+      "winRate": 30.0,
+      "expectancy": -1.11,
+      "profitFactor": 0.63,
+      "maxDrawdown": -22.76,
+      "sharpe": -0.71,
+      "annualReturn": -11.7
+    },
+    {
+      "buyScore": 80,
+      "watchScore": 64,
+      "totalTrades": 10,
+      "winRate": 30.0,
+      "expectancy": -1.11,
+      "profitFactor": 0.63,
+      "maxDrawdown": -22.76,
+      "sharpe": -0.71,
+      "annualReturn": -11.7
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -168,7 +168,20 @@
 
     <!-- 复盘 -->
     <section id="panel-review" class="tab-panel" role="tabpanel" hidden>
-      <section class="review-stats" id="review-stats"></section>
+      <section class="panel panel--inline">
+        <div class="panel__head">
+          <h2>信号复盘</h2>
+          <p id="review-signal-summary">跟踪荐股信号从开仓到平仓的胜率与收益</p>
+        </div>
+        <div class="review-stats" id="review-signal-stats"></div>
+      </section>
+      <section class="panel panel--inline">
+        <div class="panel__head">
+          <h2>荐股存档统计</h2>
+          <p id="review-reco-hint">历史荐股快照与现价对比</p>
+        </div>
+        <section class="review-stats" id="review-stats"></section>
+      </section>
       <section class="panel panel--wide">
         <div class="panel__head">
           <h2>信号生命周期</h2>
@@ -233,6 +246,36 @@
           <div id="lab-by-market"></div>
         </section>
       </div>
+      <section class="panel panel--wide">
+        <div class="panel__head">
+          <h2>参数网格搜索</h2>
+          <p id="param-sweep-summary">每周自动扫描 BUY / WATCH 评分阈值</p>
+        </div>
+        <p class="param-sweep__recommendation" id="param-sweep-recommendation" hidden></p>
+        <div class="table-wrap">
+          <table class="data-table param-sweep-table" id="param-sweep-table">
+            <thead>
+              <tr>
+                <th>BUY</th>
+                <th>WATCH</th>
+                <th>交易数</th>
+                <th>胜率</th>
+                <th>期望值</th>
+                <th>盈亏比</th>
+                <th>最大回撤</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+      <section class="panel panel--wide">
+        <div class="panel__head">
+          <h2>策略版本档案</h2>
+          <p id="strategy-versions-summary">历次参数变更记录</p>
+        </div>
+        <div class="strategy-versions" id="strategy-versions-list"></div>
+      </section>
       <section class="panel panel--wide">
         <div class="panel__head">
           <h2>回测交易记录</h2>

--- a/js/app.js
+++ b/js/app.js
@@ -4,6 +4,8 @@ const WENCAI_URL = "data/wencai.json";
 const BACKTEST_URL = "data/backtest.json";
 const PAPER_URL = "data/paper_account.json";
 const DIAGNOSTICS_URL = "data/diagnostics.json";
+const PARAM_SWEEP_URL = "data/param_sweep.json";
+const STRATEGY_VERSIONS_URL = "data/strategy_versions.json";
 const POLL_INTERVAL_MS = 5 * 60 * 1000;
 
 let lastUpdatedAt = null;
@@ -15,6 +17,8 @@ let signalsData = null;
 let backtestData = null;
 let paperData = null;
 let wencaiData = null;
+let paramSweepData = null;
+let strategyVersionsData = null;
 let lastWencaiUpdatedAt = null;
 let yahooNews = [];
 let newsFilter = "all";
@@ -494,6 +498,50 @@ function buildReviewStats(history, prices) {
   };
 }
 
+function renderReviewSignalStats(diag) {
+  const el = document.getElementById("review-signal-stats");
+  const summaryEl = document.getElementById("review-signal-summary");
+  if (!el) return;
+
+  const summary = diag?.summary || {};
+  const closed = summary.closedSignals ?? 0;
+  const hasStats = closed > 0 && summary.winRate !== null && summary.winRate !== undefined;
+
+  if (summaryEl) {
+    summaryEl.textContent = closed
+      ? `已平仓 ${closed} 笔 · 持仓 ${summary.openSignals ?? 0} 笔 · 策略 ${diag?.strategyVersion || "--"}`
+      : "信号积累中，平仓后将统计胜率与平均收益";
+  }
+
+  renderStatCards("review-signal-stats", [
+    {
+      label: "信号胜率",
+      value: hasStats ? `${summary.winRate}%` : "--",
+      hint: closed ? `已平仓 ${closed} 笔` : "暂无平仓信号",
+    },
+    {
+      label: "平均收益",
+      value: hasStats ? formatPct(summary.avgReturn) : "--",
+      valueClass: hasStats ? changeClass(summary.avgReturn) : "",
+      hint: "单笔信号收益率",
+    },
+    {
+      label: "模拟盘收益",
+      value: formatPct(summary.paperReturn),
+      valueClass: changeClass(summary.paperReturn),
+      hint: "虚拟账户总回报",
+    },
+    {
+      label: "回测期望值",
+      value: summary.backtestExpectancy !== undefined && summary.backtestExpectancy !== null
+        ? `${formatNumber(summary.backtestExpectancy)}%`
+        : "--",
+      valueClass: changeClass(summary.backtestExpectancy),
+      hint: "历史 K 线验证",
+    },
+  ]);
+}
+
 function renderReviewStats(stats) {
   const el = document.getElementById("review-stats");
   if (!el) return;
@@ -915,6 +963,94 @@ function renderPaperPanel(paper) {
   requestAnimationFrame(() => renderPaperChart(paper.equityCurve, true));
 }
 
+function renderParamSweep(data) {
+  const summaryEl = document.getElementById("param-sweep-summary");
+  const recEl = document.getElementById("param-sweep-recommendation");
+  const tbody = document.querySelector("#param-sweep-table tbody");
+  if (!tbody) return;
+
+  if (!data?.results?.length) {
+    if (summaryEl) summaryEl.textContent = "参数扫描数据尚未生成，每周日自动运行";
+    if (recEl) recEl.hidden = true;
+    tbody.innerHTML = '<tr><td colspan="7" class="empty">暂无扫描结果</td></tr>';
+    return;
+  }
+
+  const current = data.current;
+  const best = data.best;
+  if (summaryEl) {
+    summaryEl.textContent = `回测 ${data.period || "1y"} · ${data.results.length} 组组合 · 最少 ${data.minTrades ?? 8} 笔交易`;
+  }
+  if (recEl && data.recommendation) {
+    recEl.textContent = data.recommendation;
+    recEl.hidden = false;
+  }
+
+  const isCurrent = (row) =>
+    current && row.buyScore === current.buyScore && row.watchScore === current.watchScore;
+  const isBest = (row) =>
+    best && row.buyScore === best.buyScore && row.watchScore === best.watchScore;
+
+  tbody.innerHTML = data.results
+    .slice(0, 15)
+    .map((row) => {
+      const tags = [];
+      if (isCurrent(row)) tags.push('<span class="param-tag param-tag--current">当前</span>');
+      if (isBest(row)) tags.push('<span class="param-tag param-tag--best">最优</span>');
+      return `
+      <tr class="${isBest(row) ? "param-sweep-row--best" : ""}">
+        <td>${row.buyScore}${tags.length ? ` ${tags.join(" ")}` : ""}</td>
+        <td>${row.watchScore}</td>
+        <td>${row.totalTrades}</td>
+        <td>${row.winRate}%</td>
+        <td class="change ${changeClass(row.expectancy)}">${formatNumber(row.expectancy)}%</td>
+        <td>${row.profitFactor}</td>
+        <td>${row.maxDrawdown}%</td>
+      </tr>
+    `;
+    })
+    .join("");
+}
+
+function renderStrategyVersions(data) {
+  const el = document.getElementById("strategy-versions-list");
+  const summaryEl = document.getElementById("strategy-versions-summary");
+  if (!el) return;
+
+  const versions = data?.versions || [];
+  if (summaryEl) {
+    summaryEl.textContent = versions.length
+      ? `当前 ${data.current || "--"} · 共 ${versions.length} 个版本`
+      : "暂无版本记录";
+  }
+  if (!versions.length) {
+    el.innerHTML = '<p class="empty">暂无策略版本档案</p>';
+    return;
+  }
+
+  el.innerHTML = [...versions]
+    .reverse()
+    .map((v) => {
+      const params = v.params || {};
+      const paramStr = Object.entries(params)
+        .map(([k, val]) => `${k}=${val}`)
+        .join(" · ");
+      const isCurrent = v.version === data.current;
+      return `
+      <article class="strategy-version ${isCurrent ? "strategy-version--current" : ""}">
+        <div class="strategy-version__head">
+          <strong>${v.version}</strong>
+          ${isCurrent ? '<span class="param-tag param-tag--current">当前</span>' : ""}
+          <span class="strategy-version__date">${formatDateTime(v.createdAt).slice(0, 10)}</span>
+        </div>
+        <p class="strategy-version__name">${v.name || ""}</p>
+        <p class="strategy-version__params">${paramStr}</p>
+      </article>
+    `;
+    })
+    .join("");
+}
+
 function renderLabVersionCompare(backtest) {
   const el = document.getElementById("lab-version-compare");
   if (!el || !backtest?.compareWith) {
@@ -1256,7 +1392,20 @@ function applyTradingData(payload) {
   if (diagnostics) {
     diagnosticsData = diagnostics;
     renderDiagnostics(diagnostics);
+    renderReviewSignalStats(diagnostics);
     renderCockpitSystem(diagnostics, backtestData);
+  }
+}
+
+function applyLabExtras(payload) {
+  const { paramSweep, strategyVersions } = payload;
+  if (paramSweep) {
+    paramSweepData = paramSweep;
+    renderParamSweep(paramSweep);
+  }
+  if (strategyVersions) {
+    strategyVersionsData = strategyVersions;
+    renderStrategyVersions(strategyVersions);
   }
 }
 
@@ -1272,16 +1421,19 @@ function tradingDataStamp(signals, backtest, paper, diagnostics) {
 
 async function refreshTradingData() {
   try {
-    const [signals, backtest, paper, diagnostics] = await Promise.all([
+    const [signals, backtest, paper, diagnostics, paramSweep, strategyVersions] = await Promise.all([
       fetchJson(SIGNALS_URL),
       fetchJson(BACKTEST_URL),
       fetchJson(PAPER_URL),
       fetchJson(DIAGNOSTICS_URL),
+      fetchJson(PARAM_SWEEP_URL),
+      fetchJson(STRATEGY_VERSIONS_URL),
     ]);
     const stamp = tradingDataStamp(signals, backtest, paper, diagnostics);
     const needsPaper = !paperData && paper;
     if (stamp && stamp === lastTradingUpdatedAt && !needsPaper) return;
     applyTradingData({ signals, backtest, paper, diagnostics });
+    applyLabExtras({ paramSweep, strategyVersions });
     lastTradingUpdatedAt = stamp;
   } catch (error) {
     console.error("trading data load failed", error);

--- a/js/app.js
+++ b/js/app.js
@@ -2,6 +2,7 @@ const DATA_URL = "data/market.json";
 const HISTORY_URL = "data/reco_history.json";
 const WENCAI_URL = "data/wencai.json";
 const BACKTEST_URL = "data/backtest.json";
+const SIGNALS_URL = "data/signals.json";
 const PAPER_URL = "data/paper_account.json";
 const DIAGNOSTICS_URL = "data/diagnostics.json";
 const PARAM_SWEEP_URL = "data/param_sweep.json";
@@ -1410,9 +1411,14 @@ function applyLabExtras(payload) {
 }
 
 async function fetchJson(url) {
-  const response = await fetch(`${url}?t=${Date.now()}`, { cache: "no-store" });
-  if (!response.ok) return null;
-  return response.json();
+  try {
+    const response = await fetch(`${url}?t=${Date.now()}`, { cache: "no-store" });
+    if (!response.ok) return null;
+    return await response.json();
+  } catch (error) {
+    console.error(`fetch failed: ${url}`, error);
+    return null;
+  }
 }
 
 function tradingDataStamp(signals, backtest, paper, diagnostics) {
@@ -1437,7 +1443,7 @@ async function refreshTradingData() {
     lastTradingUpdatedAt = stamp;
   } catch (error) {
     console.error("trading data load failed", error);
-    if (activeTab === "paper") renderPaperPanel(null);
+    if (activeTab === "paper" && !paperData) renderPaperPanel(null);
   }
 }
 

--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -80,7 +80,12 @@ def bench_closes_up_to(
     return series
 
 
-def simulate_symbol(symbol: str, bench_by_date: dict[str, float]) -> list[dict]:
+def simulate_symbol(
+    symbol: str,
+    bench_by_date: dict[str, float],
+    buy_score: float | None = None,
+    watch_score: float | None = None,
+) -> list[dict]:
     market = MARKET_MAP.get(symbol, "美股")
     try:
         hist = yf.Ticker(symbol).history(period=BACKTEST_PERIOD, interval="1d")
@@ -105,6 +110,8 @@ def simulate_symbol(symbol: str, bench_by_date: dict[str, float]) -> list[dict]:
             volumes[: i + 1],
             bench_slice,
             market,
+            buy_score=buy_score,
+            watch_score=watch_score,
         )
         if not scored or scored["signal"] != "buy":
             i += 1
@@ -208,8 +215,11 @@ def compute_metrics(trades: list[dict]) -> dict:
     }
 
 
-def main() -> None:
-    DATA_DIR.mkdir(parents=True, exist_ok=True)
+def run_backtest(
+    buy_score: float | None = None,
+    watch_score: float | None = None,
+) -> tuple[list[dict], dict, dict[str, dict]]:
+    """运行回测，返回 (全部交易, 汇总指标, 分市场指标)。"""
     bench_maps = load_benchmark_series(BACKTEST_PERIOD)
     all_trades: list[dict] = []
     by_market: dict[str, list[dict]] = {}
@@ -217,12 +227,18 @@ def main() -> None:
     for symbol in BACKTEST_UNIVERSE:
         market = MARKET_MAP.get(symbol, "美股")
         bench_by_date = bench_maps.get(market, {})
-        trades = simulate_symbol(symbol, bench_by_date)
+        trades = simulate_symbol(symbol, bench_by_date, buy_score, watch_score)
         all_trades.extend(trades)
         by_market.setdefault(market, []).extend(trades)
 
     metrics = compute_metrics(all_trades)
     market_metrics = {m: compute_metrics(t) for m, t in by_market.items()}
+    return all_trades, metrics, market_metrics
+
+
+def main() -> None:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    all_trades, metrics, market_metrics = run_backtest()
 
     payload = {
         "updatedAt": datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds"),

--- a/scripts/optimize_params.py
+++ b/scripts/optimize_params.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""策略参数网格搜索 — 离线构建脚本，每周与回测一并运行，写入 data/param_sweep.json。"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from itertools import product
+from pathlib import Path
+
+from backtest import run_backtest
+from strategy_config import BACKTEST_PERIOD, BUY_SCORE, STRATEGY_VERSION, WATCH_SCORE
+
+ROOT = Path(__file__).resolve().parent.parent
+DATA_DIR = ROOT / "data"
+OUTPUT_FILE = DATA_DIR / "param_sweep.json"
+
+BUY_SCORE_GRID = [72, 74, 76, 78, 80]
+WATCH_SCORE_GRID = [56, 58, 60, 62, 64]
+MIN_TRADES = 8
+
+
+def sweep() -> list[dict]:
+    results: list[dict] = []
+    for buy_score, watch_score in product(BUY_SCORE_GRID, WATCH_SCORE_GRID):
+        if watch_score >= buy_score - 8:
+            continue
+        _, metrics, _ = run_backtest(buy_score=buy_score, watch_score=watch_score)
+        results.append(
+            {
+                "buyScore": buy_score,
+                "watchScore": watch_score,
+                "totalTrades": metrics["totalTrades"],
+                "winRate": metrics["winRate"],
+                "expectancy": metrics["expectancy"],
+                "profitFactor": metrics["profitFactor"],
+                "maxDrawdown": metrics["maxDrawdown"],
+                "sharpe": metrics["sharpe"],
+                "annualReturn": metrics["annualReturn"],
+            }
+        )
+    return results
+
+
+def pick_best(results: list[dict]) -> dict | None:
+    eligible = [r for r in results if r["totalTrades"] >= MIN_TRADES]
+    if not eligible:
+        return None
+    return max(eligible, key=lambda r: (r["expectancy"], r["profitFactor"], r["winRate"]))
+
+
+def main() -> None:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    results = sweep()
+    best = pick_best(results)
+    current = next(
+        (r for r in results if r["buyScore"] == BUY_SCORE and r["watchScore"] == WATCH_SCORE),
+        None,
+    )
+
+    payload = {
+        "updatedAt": datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds"),
+        "strategyVersion": STRATEGY_VERSION,
+        "period": BACKTEST_PERIOD,
+        "grid": {"buyScore": BUY_SCORE_GRID, "watchScore": WATCH_SCORE_GRID},
+        "minTrades": MIN_TRADES,
+        "current": current,
+        "best": best,
+        "recommendation": None,
+        "results": sorted(results, key=lambda r: (-r["expectancy"], -r["winRate"])),
+    }
+
+    if best and current:
+        if best["buyScore"] == current["buyScore"] and best["watchScore"] == current["watchScore"]:
+            payload["recommendation"] = "当前参数已在网格搜索中表现最优，无需调整。"
+        elif best["expectancy"] > current["expectancy"] + 0.15:
+            payload["recommendation"] = (
+                f"建议考虑 BUY_SCORE={best['buyScore']}、WATCH_SCORE={best['watchScore']} "
+                f"（期望 {best['expectancy']}% vs 当前 {current['expectancy']}%）。"
+            )
+        else:
+            payload["recommendation"] = "当前参数与最优组合接近，维持现状即可。"
+    elif best:
+        payload["recommendation"] = (
+            f"网格最优：BUY_SCORE={best['buyScore']}、WATCH_SCORE={best['watchScore']}。"
+        )
+
+    OUTPUT_FILE.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"Wrote {OUTPUT_FILE} ({len(results)} combos, best expectancy {best['expectancy'] if best else 'n/a'})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/strategy_scoring.py
+++ b/scripts/strategy_scoring.py
@@ -108,6 +108,8 @@ def score_series(
     volumes: list[float],
     bench_closes: list[float],
     market: str = "美股",
+    buy_score: float | None = None,
+    watch_score: float | None = None,
 ) -> dict | None:
     """对截至最新一根 K 线的序列打分，与实盘荐股逻辑一致。"""
     if len(closes) < 65:
@@ -212,14 +214,17 @@ def score_series(
     if not (sma10 and sma10 > sma20 > sma60):
         hard_ok = False
 
-    if score >= BUY_SCORE and hard_ok:
+    buy_threshold = buy_score if buy_score is not None else BUY_SCORE
+    watch_threshold = watch_score if watch_score is not None else WATCH_SCORE
+
+    if score >= buy_threshold and hard_ok:
         signal, signal_label = "buy", "建议买入"
-    elif score >= WATCH_SCORE:
+    elif score >= watch_threshold:
         signal, signal_label = "watch", "建议观察"
     else:
         signal, signal_label = "hold", "暂不参与"
 
-    strong_trend = bool(sma10 and sma10 > sma20 > sma60 and score >= BUY_SCORE)
+    strong_trend = bool(sma10 and sma10 > sma20 > sma60 and score >= buy_threshold)
     atr_mult = ATR_STOP_STRONG if strong_trend else ATR_STOP_NORMAL
     stop_loss = round(price - atr_mult * atr, 2)
     target = round(price + atr_mult * atr * REWARD_RISK_RATIO, 2)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

实现路线图中的「策略参数自动优化」能力：每周回测时自动扫描 BUY/WATCH 评分阈值组合，并在实验室与复盘 Tab 展示结果。

## 变更

### 离线脚本
- `strategy_scoring.score_series` 支持可选 `buy_score` / `watch_score` 覆盖
- `backtest.run_backtest()` 抽取为可复用入口
- 新增 `scripts/optimize_params.py`，网格搜索 24 组参数并写入 `data/param_sweep.json`
- `weekly-backtest.yml` 在回测后追加参数扫描步骤

### 前端
- **实验室**：参数网格搜索表（标注当前/最优组合）+ 策略版本档案
- **复盘 Tab**：拆分「信号复盘」与「荐股存档统计」，信号侧展示胜率、均收益、模拟盘与回测期望

### 数据
- 首次运行扫描结果：当前 v1.1.0（BUY=78, WATCH=62）期望 0.25%；网格最优 BUY=74/WATCH=56 期望 0.73%

## 验证

- [x] 本地运行 `python3 scripts/optimize_params.py` 成功生成 `param_sweep.json`
- [x] 前端加载 `param_sweep.json` 与 `strategy_versions.json` 无报错

## 后续

- 若采纳网格最优参数，可另开 PR 更新 `strategy_config.py` 并 bump 至 v1.2.0
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62fa50dd-4422-4777-aa97-3de214aa93a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62fa50dd-4422-4777-aa97-3de214aa93a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

