### PR TITLE
feat: 接入 FRED 与 Finnhub 宏观数据源

### DIFF
--- a/.github/API_KEYS_SETUP.md
+++ b/.github/API_KEYS_SETUP.md
@@ -1,0 +1,52 @@
+# FRED / Finnhub API Key 配置指南
+
+宏观模块 `scripts/fetch_macro.py` 在免费源（Yahoo Finance、Frankfurter）之外，可选接入：
+
+| Secret | 用途 | 注册地址 |
+|--------|------|----------|
+| `FRED_API_KEY` | 美国官方宏观序列（10Y-2Y 利差、失业率、CPI 等） | [FRED API Keys](https://fred.stlouisfed.org/docs/api/api_key.html) |
+| `FINNHUB_API_KEY` | 全球/外汇新闻、财报日历 | [Finnhub 注册](https://finnhub.io/register) |
+
+未配置时站点仍可正常运行，对应区块显示空状态或仅免费源数据。
+
+## GitHub Actions 配置
+
+1. 打开仓库 **Settings → Secrets and variables → Actions**
+2. 新建 **Repository secret**：
+   - Name: `FRED_API_KEY` — 粘贴 FRED 控制台生成的 Key
+   - Name: `FINNHUB_API_KEY` — 粘贴 Finnhub Dashboard 中的 API Key
+3. 保存后，以下工作流会自动注入环境变量：
+   - `.github/workflows/update-market-data.yml`（每 5 分钟）
+   - `.github/workflows/generate-investment-report.yml`（每日 9/12/16 点研报）
+
+```yaml
+env:
+  FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
+  FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
+```
+
+## 本地开发
+
+```bash
+export FRED_API_KEY='你的fred_key'
+export FINNHUB_API_KEY='你的finnhub_key'
+python scripts/fetch_macro.py
+```
+
+## 验证
+
+成功时 `data/macro.json` 中：
+
+- `sources` 里 `fred` / `finnhub` 的 `"cookieUsed": true`（表示 Key 已传入）
+- `"fred"` 数组含 6 条官方序列（或 `status: partial`）
+- `"finnhubNews"` 含宏观/外汇新闻
+- `"earningsCalendar"` 含关注标的财报（AAPL、NVDA、1810.HK、0700.HK、688981.SS 等）
+- `summary.yieldSpread10y2y` 有 10Y-2Y 利差数值
+
+CI 在 `update-market-data` 工作流中会自动打印 `fred keyUsed` / `finnhub keyUsed` 日志。
+
+## 注意事项
+
+- FRED 免费层足够本项目使用；Finnhub 免费层有速率限制，本脚本已控制请求量
+- Key 泄露请立即在对应平台轮换
+- 问财 Cookie 配置见 [WENCAI_SETUP.md](./WENCAI_SETUP.md)

--- a/.github/workflows/generate-investment-report.yml
+++ b/.github/workflows/generate-investment-report.yml
@@ -42,6 +42,9 @@ jobs:
         run: pip install -r scripts/requirements.txt
 
       - name: Refresh market data
+        env:
+          FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
+          FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
         run: |
           python scripts/fetch_data.py
           python scripts/fetch_macro.py

--- a/.github/workflows/update-market-data.yml
+++ b/.github/workflows/update-market-data.yml
@@ -28,9 +28,27 @@ jobs:
         run: pip install -r scripts/requirements.txt
 
       - name: Fetch market data
+        env:
+          FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
+          FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
         run: |
           python scripts/fetch_data.py
           python scripts/fetch_macro.py
+
+      - name: Verify macro output
+        run: |
+          python3 - <<'PY'
+          import json
+          d = json.load(open("data/macro.json", encoding="utf-8"))
+          fred_src = next((s for s in d.get("sources", []) if s.get("id") == "fred"), {})
+          fh_src = next((s for s in d.get("sources", []) if s.get("id") == "finnhub"), {})
+          print("fred keyUsed:", fred_src.get("cookieUsed"), "status:", fred_src.get("status"), "items:", fred_src.get("items"))
+          print("finnhub keyUsed:", fh_src.get("cookieUsed"), "status:", fh_src.get("status"), "items:", fh_src.get("items"))
+          if fred_src.get("cookieUsed") and not d.get("fred"):
+              print("WARN: FRED_API_KEY 已配置但未拉取到序列")
+          if fh_src.get("cookieUsed") and not d.get("finnhubNews") and not d.get("earningsCalendar"):
+              print("WARN: FINNHUB_API_KEY 已配置但未拉取到新闻/财报")
+          PY
 
       - name: Run trading engine
         run: python scripts/trading_engine.py

--- a/css/styles.css
+++ b/css/styles.css
@@ -779,6 +779,11 @@ a:hover {
   color: var(--accent);
 }
 
+.news-source--finnhub {
+  background: rgba(16, 185, 129, 0.15);
+  color: #6ee7b7;
+}
+
 .history-filter {
   border: 1px solid var(--border);
   background: var(--bg-card);

--- a/data/macro.json
+++ b/data/macro.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-06-27T03:22:57+00:00",
+  "updatedAt": "2026-06-27T04:16:33+00:00",
   "sources": [
     {
       "id": "yahoo",
@@ -12,6 +12,20 @@
       "name": "Frankfurter (ECB)",
       "status": "ok",
       "items": 7
+    },
+    {
+      "id": "fred",
+      "name": "FRED (St. Louis Fed)",
+      "status": "missing_key",
+      "items": 0,
+      "cookieUsed": false
+    },
+    {
+      "id": "finnhub",
+      "name": "Finnhub",
+      "status": "missing_key",
+      "items": 0,
+      "cookieUsed": false
     }
   ],
   "summary": {
@@ -22,6 +36,7 @@
     "usdCnhChangePct": null,
     "sectorLeader": "健康",
     "sectorLaggard": "科技",
+    "yieldSpread10y2y": null,
     "hints": [
       "美债收益率回落，利于风险资产估值修复。",
       "美股行业轮动：健康 领涨（+3.03%），科技 靠后。",
@@ -204,10 +219,10 @@
       "unit": "USD/oz",
       "currency": "USD",
       "region": null,
-      "price": 4103.0,
-      "changePct": 1.8,
-      "weekChangePct": -2.87,
-      "monthChangePct": -7.75,
+      "price": 4078.7,
+      "changePct": 1.2,
+      "weekChangePct": -3.44,
+      "monthChangePct": -8.29,
       "source": "yahoo"
     },
     {
@@ -217,10 +232,10 @@
       "unit": "USD/bbl",
       "currency": "USD",
       "region": null,
-      "price": 70.24,
-      "changePct": -2.34,
-      "weekChangePct": -8.3,
-      "monthChangePct": -20.79,
+      "price": 69.23,
+      "changePct": -3.74,
+      "weekChangePct": -9.62,
+      "monthChangePct": -21.93,
       "source": "yahoo"
     },
     {
@@ -230,10 +245,10 @@
       "unit": "USD/lb",
       "currency": "USD",
       "region": null,
-      "price": 6.2,
-      "changePct": 2.09,
-      "weekChangePct": -2.78,
-      "monthChangePct": -1.7,
+      "price": 6.14,
+      "changePct": 1.17,
+      "weekChangePct": -3.66,
+      "monthChangePct": -2.59,
       "source": "yahoo"
     }
   ],
@@ -433,5 +448,8 @@
       "source": "yahoo",
       "sector": "科技"
     }
-  ]
+  ],
+  "fred": [],
+  "finnhubNews": [],
+  "earningsCalendar": []
 }

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/jsmind@0.8.7/es6/jsmind.js" defer></script>
   <script src="js/ai-mindmap.js" defer></script>
-  <script src="js/app.js?v=21" defer></script>
+  <script src="js/app.js?v=22" defer></script>
 </head>
 <body>
   <div class="app">

--- a/js/app.js
+++ b/js/app.js
@@ -276,6 +276,39 @@ function formatMacroPrice(item) {
   return formatNumber(item.price);
 }
 
+function formatFredValue(item) {
+  if (!item) return "--";
+  const unit = item.unit;
+  if (unit === "pct" || unit === "spread") return `${formatNumber(item.price, item.unit === "spread" ? 2 : 2)}%`;
+  if (unit === "rate") return formatNumber(item.price, 4);
+  return formatNumber(item.price);
+}
+
+function renderMacroNewsList(news) {
+  if (!news?.length) {
+    return '<p class="empty">暂无 Finnhub 宏观资讯（配置 FINNHUB_API_KEY 后自动拉取）</p>';
+  }
+  return `<ul class="news-list news-list--compact">${news
+    .map(
+      (item) => `
+      <li class="news-item news-item--compact">
+        <div>
+          <p class="news-item__title">
+            ${item.link ? `<a href="${item.link}" target="_blank" rel="noopener noreferrer">${item.title}</a>` : item.title}
+          </p>
+          ${item.summary ? `<p class="news-item__summary">${item.summary}</p>` : ""}
+          <p class="news-item__meta">
+            <span class="news-source news-source--finnhub">${item.source || "Finnhub"}</span>
+            ${item.category ? ` · ${item.category}` : ""}${item.related ? ` · ${item.related}` : ""}
+          </p>
+        </div>
+        <span class="news-item__time">${formatDateTime(item.publishedAt)}</span>
+      </li>
+    `
+    )
+    .join("")}</ul>`;
+}
+
 function renderCockpitMacro(data) {
   const grid = document.getElementById("cockpit-macro-grid");
   const hintsEl = document.getElementById("cockpit-macro-hints");
@@ -292,6 +325,7 @@ function renderCockpitMacro(data) {
     const parts = [];
     if (s.vix != null) parts.push(`VIX ${formatNumber(s.vix, 1)}`);
     if (s.us10yYield != null) parts.push(`10Y ${formatNumber(s.us10yYield, 2)}%`);
+    if (s.yieldSpread10y2y != null) parts.push(`10Y-2Y ${formatNumber(s.yieldSpread10y2y, 2)}%`);
     if (s.usdCnh != null) parts.push(`USDCNH ${formatNumber(s.usdCnh, 4)}`);
     hint.textContent = parts.length ? parts.join(" · ") : "VIX · 利率 · 汇率 · 商品 · 美股行业";
   }
@@ -416,6 +450,27 @@ function renderMarketMacro(data) {
         { label: "价格", render: (r) => formatNumber(r.price) },
         { label: "日涨跌", render: (r) => `<span class="change ${changeClass(r.changePct)}">${formatPct(r.changePct)}</span>` },
         { label: "周涨跌", render: (r) => `<span class="change ${changeClass(r.weekChangePct)}">${formatPct(r.weekChangePct)}</span>` },
+      ])}
+      ${renderMacroTable("FRED 官方宏观", "圣路易斯联储 · 需 FRED_API_KEY", data.fred || [], [
+        { label: "序列", render: (r) => `<strong>${r.name}</strong> <span class="stock-card__symbol">${r.seriesId}</span>` },
+        { label: "最新", render: (r) => formatFredValue(r) },
+        { label: "变动", render: (r) => `<span class="change ${changeClass(r.changePct)}">${formatPct(r.changePct)}</span>` },
+        { label: "观测日", render: (r) => r.observedAt || "—" },
+        { label: "来源", key: "source" },
+      ])}
+      <section class="macro-block">
+        <div class="panel__head">
+          <h3>Finnhub 宏观资讯</h3>
+          <p>全球市场 · 外汇 · 免费层 API</p>
+        </div>
+        ${renderMacroNewsList(data.finnhubNews)}
+      </section>
+      ${renderMacroTable("财报日历（关注标的）", "AAPL · NVDA · 小米 · 腾讯 · 中芯", data.earningsCalendar || [], [
+        { label: "代码", render: (r) => `<strong>${r.symbol || "—"}</strong>` },
+        { label: "日期", render: (r) => r.date || "—" },
+        { label: "时段", render: (r) => r.hour || "—" },
+        { label: "EPS 预期", render: (r) => (r.epsEstimate != null ? formatNumber(r.epsEstimate, 2) : "—") },
+        { label: "营收预期", render: (r) => (r.revenueEstimate != null ? formatNumber(r.revenueEstimate, 0) : "—") },
       ])}
     </div>
   `;

--- a/scripts/fetch_macro.py
+++ b/scripts/fetch_macro.py
@@ -4,9 +4,11 @@
 from __future__ import annotations
 
 import json
+import os
 import urllib.error
+import urllib.parse
 import urllib.request
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import yfinance as yf
@@ -51,6 +53,18 @@ SECTOR_ETFS = {
     "XLRE": "地产",
     "XLC": "通信",
 }
+
+# FRED 宏观序列（需 FRED_API_KEY）
+FRED_SERIES = {
+    "DGS10": {"name": "美10年期国债收益率", "unit": "pct", "digits": 2},
+    "T10Y2Y": {"name": "10Y-2Y 利差", "unit": "spread", "digits": 2},
+    "FEDFUNDS": {"name": "联邦基金利率", "unit": "pct", "digits": 2},
+    "UNRATE": {"name": "美国失业率", "unit": "pct", "digits": 1},
+    "DEXCHUS": {"name": "美元/人民币(官方)", "unit": "rate", "digits": 4},
+    "CPIAUCSL": {"name": "美国CPI指数", "unit": "index", "digits": 1},
+}
+
+FINNHUB_WATCH = ("AAPL", "NVDA", "1810.HK", "0700.HK", "688981.SS")
 
 
 def pct_change(current: float | None, previous: float | None) -> float | None:
@@ -197,6 +211,176 @@ def merge_fx(yahoo_fx: list[dict], static_fx: list[dict]) -> list[dict]:
     return result
 
 
+def http_get_json(url: str, timeout: int = 25) -> dict | list | None:
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read())
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, ValueError):
+        return None
+
+
+def fetch_fred_series(api_key: str, series_id: str, meta: dict) -> dict | None:
+    params = urllib.parse.urlencode(
+        {
+            "series_id": series_id,
+            "api_key": api_key,
+            "file_type": "json",
+            "sort_order": "desc",
+            "limit": 6,
+        }
+    )
+    url = f"https://api.stlouisfed.org/fred/series/observations?{params}"
+    data = http_get_json(url)
+    if not isinstance(data, dict):
+        return None
+
+    obs = [o for o in data.get("observations", []) if o.get("value") not in (".", None, "")]
+    if not obs:
+        return None
+
+    latest = obs[0]
+    prev = obs[1] if len(obs) > 1 else None
+    month_ago = obs[5] if len(obs) > 5 else None
+
+    try:
+        val = float(latest["value"])
+        prev_val = float(prev["value"]) if prev else None
+        month_val = float(month_ago["value"]) if month_ago else None
+    except (TypeError, ValueError):
+        return None
+
+    digits = meta.get("digits", 2)
+    change = pct_change(val, prev_val)
+    if series_id == "CPIAUCSL" and month_val:
+        change = pct_change(val, month_val)
+
+    return {
+        "seriesId": series_id,
+        "name": meta["name"],
+        "unit": meta.get("unit", "index"),
+        "price": round(val, digits),
+        "changePct": change,
+        "observedAt": latest.get("date"),
+        "source": "fred",
+    }
+
+
+def fetch_fred_all(api_key: str | None) -> tuple[list[dict], str]:
+    if not api_key:
+        return [], "missing_key"
+    items = []
+    errors = 0
+    for series_id, meta in FRED_SERIES.items():
+        row = fetch_fred_series(api_key, series_id, meta)
+        if row:
+            items.append(row)
+        else:
+            errors += 1
+    status = "ok" if items else "error"
+    if items and errors:
+        status = "partial"
+    return items, status
+
+
+def fetch_finnhub_news(api_key: str | None, category: str = "general", limit: int = 8) -> list[dict]:
+    if not api_key:
+        return []
+    params = urllib.parse.urlencode({"category": category, "token": api_key})
+    data = http_get_json(f"https://finnhub.io/api/v1/news?{params}")
+    if not isinstance(data, list):
+        return []
+
+    items = []
+    for row in data[:limit]:
+        ts = row.get("datetime")
+        published = None
+        if ts:
+            published = datetime.fromtimestamp(int(ts), tz=timezone.utc).isoformat()
+        items.append(
+            {
+                "id": row.get("id"),
+                "title": row.get("headline") or row.get("title"),
+                "summary": (row.get("summary") or "")[:200],
+                "source": row.get("source") or "Finnhub",
+                "category": category,
+                "link": row.get("url") or "",
+                "publishedAt": published,
+                "related": row.get("related") or "",
+            }
+        )
+    return items
+
+
+def fetch_finnhub_earnings(api_key: str | None, days: int = 7) -> list[dict]:
+    if not api_key:
+        return []
+    today = datetime.now(timezone.utc).date()
+    end = today + timedelta(days=days)
+    params = urllib.parse.urlencode(
+        {
+            "from": today.isoformat(),
+            "to": end.isoformat(),
+            "token": api_key,
+        }
+    )
+    data = http_get_json(f"https://finnhub.io/api/v1/calendar/earnings?{params}")
+    if not isinstance(data, dict):
+        return []
+
+    rows = data.get("earningsCalendar") or []
+    watch = set(FINNHUB_WATCH)
+    items = []
+    for row in rows[:40]:
+        symbol = row.get("symbol") or ""
+        if watch and symbol not in watch:
+            continue
+        items.append(
+            {
+                "symbol": symbol,
+                "date": row.get("date"),
+                "hour": row.get("hour"),
+                "epsEstimate": row.get("epsEstimate"),
+                "revenueEstimate": row.get("revenueEstimate"),
+            }
+        )
+    if not items and rows:
+        items = [
+            {
+                "symbol": row.get("symbol"),
+                "date": row.get("date"),
+                "hour": row.get("hour"),
+                "epsEstimate": row.get("epsEstimate"),
+                "revenueEstimate": row.get("revenueEstimate"),
+            }
+            for row in rows[:10]
+        ]
+    return items[:12]
+
+
+def fetch_finnhub_all(api_key: str | None) -> tuple[dict, str]:
+    if not api_key:
+        return {"news": [], "earnings": []}, "missing_key"
+
+    news = fetch_finnhub_news(api_key, "general", 8)
+    forex_news = fetch_finnhub_news(api_key, "forex", 4)
+    earnings = fetch_finnhub_earnings(api_key)
+
+    seen: set[str] = set()
+    merged_news = []
+    for item in news + forex_news:
+        title = item.get("title") or ""
+        if not title or title in seen:
+            continue
+        seen.add(title)
+        merged_news.append(item)
+        if len(merged_news) >= 10:
+            break
+
+    status = "ok" if merged_news or earnings else "empty"
+    return {"news": merged_news, "earnings": earnings}, status
+
+
 def fetch_sectors() -> list[dict]:
     items = []
     for symbol, sector in SECTOR_ETFS.items():
@@ -220,7 +404,13 @@ def vix_regime(vix: float | None) -> str:
     return "normal"
 
 
-def build_summary(risk: list, fx: list, sectors: list, commodities: list) -> dict:
+def build_summary(
+    risk: list,
+    fx: list,
+    sectors: list,
+    commodities: list,
+    fred: list | None = None,
+) -> dict:
     vix_item = next((r for r in risk if r.get("symbol") == "^VIX"), None)
     tnx_item = next((r for r in risk if r.get("symbol") == "^TNX"), None)
     cnh = next((f for f in fx if "CNH" in f.get("symbol", "") or f.get("quote") == "CNH"), None)
@@ -262,6 +452,17 @@ def build_summary(risk: list, fx: list, sectors: list, commodities: list) -> dic
         elif gold["changePct"] < 0 and oil["changePct"] > 0:
             hints.append("原油强、黄金弱 — 偏再通胀/增长预期。")
 
+    spread = next((f for f in (fred or []) if f.get("seriesId") == "T10Y2Y"), None)
+    if spread and spread.get("price") is not None:
+        if spread["price"] < 0:
+            hints.append("FRED：10Y-2Y 利差为负（收益率曲线倒挂），需关注衰退预期。")
+        elif spread["price"] < 0.5:
+            hints.append("FRED：10Y-2Y 利差偏窄，宏观流动性预期趋紧。")
+
+    unrate = next((f for f in (fred or []) if f.get("seriesId") == "UNRATE"), None)
+    if unrate and unrate.get("changePct") is not None and unrate["changePct"] > 0.1:
+        hints.append("FRED：失业率边际上升，就业市场边际走弱。")
+
     return {
         "vix": vix_val,
         "vixRegime": regime,
@@ -270,7 +471,8 @@ def build_summary(risk: list, fx: list, sectors: list, commodities: list) -> dic
         "usdCnhChangePct": cnh.get("changePct") if cnh else None,
         "sectorLeader": leader.get("sector") if leader else None,
         "sectorLaggard": laggard.get("sector") if laggard else None,
-        "hints": hints[:4],
+        "yieldSpread10y2y": spread.get("price") if spread else None,
+        "hints": hints[:5],
     }
 
 
@@ -313,7 +515,31 @@ def main() -> None:
     rates = [r for r in risk_rates_indices if r.get("category") == "rates"]
     extra_indices = [r for r in risk_rates_indices if r.get("category") == "index"]
 
-    summary = build_summary(risk + rates, fx, sectors, commodities)
+    fred_key = os.environ.get("FRED_API_KEY") or None
+    finnhub_key = os.environ.get("FINNHUB_API_KEY") or None
+    fred_items, fred_status = fetch_fred_all(fred_key)
+    sources.append(
+        {
+            "id": "fred",
+            "name": "FRED (St. Louis Fed)",
+            "status": fred_status,
+            "items": len(fred_items),
+            "cookieUsed": bool(fred_key),
+        }
+    )
+
+    finnhub_data, fh_status = fetch_finnhub_all(finnhub_key)
+    sources.append(
+        {
+            "id": "finnhub",
+            "name": "Finnhub",
+            "status": fh_status,
+            "items": len(finnhub_data.get("news", [])) + len(finnhub_data.get("earnings", [])),
+            "cookieUsed": bool(finnhub_key),
+        }
+    )
+
+    summary = build_summary(risk + rates, fx, sectors, commodities, fred_items)
 
     payload = {
         "updatedAt": now.isoformat(timespec="seconds"),
@@ -325,12 +551,16 @@ def main() -> None:
         "commodities": commodities,
         "extraIndices": extra_indices,
         "sectors": sectors,
+        "fred": fred_items,
+        "finnhubNews": finnhub_data.get("news", []),
+        "earningsCalendar": finnhub_data.get("earnings", []),
     }
 
     OUTPUT_FILE.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
     print(
         f"Wrote {OUTPUT_FILE} "
-        f"(risk {len(risk)}, fx {len(fx)}, sectors {len(sectors)}, indices {len(extra_indices)})"
+        f"(risk {len(risk)}, fx {len(fx)}, sectors {len(sectors)}, "
+        f"fred {len(fred_items)}, finnhub news {len(finnhub_data.get('news', []))})"
     )
 
 

--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -411,6 +411,10 @@ def macro_section(macro: dict | None) -> str:
         lines.append(f"- **VIX** {fmt_num(s['vix'], 1)}（{s.get('vixRegime', '—')}）")
     if s.get("us10yYield") is not None:
         lines.append(f"- **美10Y收益率** {fmt_num(s['us10yYield'], 2)}%")
+    if s.get("yieldSpread10y2y") is not None:
+        spread = s["yieldSpread10y2y"]
+        tag = "倒挂" if spread < 0 else "偏窄" if spread < 0.5 else "正常"
+        lines.append(f"- **10Y-2Y 利差（FRED）** {fmt_num(spread, 2)}%（{tag}）")
     if s.get("usdCnh") is not None:
         chg = fmt_pct(s.get("usdCnhChangePct")) if s.get("usdCnhChangePct") is not None else "—"
         lines.append(f"- **USDCNH** {fmt_num(s['usdCnh'], 4)}（日 {chg}）")
@@ -418,6 +422,35 @@ def macro_section(macro: dict | None) -> str:
         lines.append(
             f"- **美股行业**：{s.get('sectorLeader')} 领涨，{s.get('sectorLaggard')} 靠后"
         )
+
+    fred_rows = macro.get("fred") or []
+    if fred_rows:
+        lines.append("\n**FRED 官方序列**")
+        for row in fred_rows[:6]:
+            chg = fmt_pct(row.get("changePct")) if row.get("changePct") is not None else "—"
+            lines.append(
+                f"- {row.get('name', row.get('seriesId'))}：{row.get('price')}（变动 {chg}，{row.get('observedAt', '—')}）"
+            )
+
+    news = macro.get("finnhubNews") or []
+    if news:
+        lines.append("\n**Finnhub 宏观要闻**")
+        for item in news[:5]:
+            title = item.get("title") or "—"
+            src = item.get("source") or "Finnhub"
+            lines.append(f"- [{title}]({item.get('link') or '#'})（{src}）")
+
+    earnings = macro.get("earningsCalendar") or []
+    if earnings:
+        lines.append("\n**财报日历（关注标的）**")
+        for row in earnings[:6]:
+            eps = row.get("epsEstimate")
+            eps_s = fmt_num(eps, 2) if eps is not None else "—"
+            lines.append(
+                f"- **{row.get('symbol', '—')}** {row.get('date', '—')} "
+                f"{row.get('hour') or ''} · EPS预期 {eps_s}"
+            )
+
     for h in s.get("hints") or []:
         lines.append(f"- {h}")
     src = "、".join(x.get("name", "") for x in macro.get("sources") or [])
@@ -464,7 +497,7 @@ def build_report(slot: str, now_bjt: datetime | None = None) -> tuple[str, dict]
 
 **{now_bjt.strftime('%Y年%m月%d日')} {time_str}（北京时间）** · {meta['subtitle']}
 
-> 数据来源：Yahoo Finance · Frankfurter(ECB) · 同花顺问财 · 量化策略引擎  
+> 数据来源：Yahoo Finance · Frankfurter(ECB) · FRED · Finnhub · 同花顺问财 · 量化策略引擎  
 > 行情更新：{fmt_dt_bjt(market.get('updatedAt'))} · 宏观：{fmt_dt_bjt(macro.get('updatedAt'))} · 问财：{fmt_dt_bjt(wencai.get('updatedAt'))}
 
 ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

在现有免费宏观源（Yahoo Finance、Frankfurter、ER-API 备用）基础上，接入 **FRED** 官方宏观序列与 **Finnhub** 新闻/财报日历。用户已在仓库 Secrets 中配置 `FRED_API_KEY` 与 `FINNHUB_API_KEY`。

## 变更

- **`scripts/fetch_macro.py`**：拉取 FRED（DGS10、T10Y2Y、FEDFUNDS、UNRATE、DEXCHUS、CPIAUCSL）与 Finnhub（general/forex 新闻、关注标的财报）
- **CI**：`update-market-data` / `generate-investment-report` 注入 Secret，并打印 keyUsed 校验日志
- **前端**：大盘 Tab 新增 FRED 表、Finnhub 资讯、财报日历；驾驶舱摘要显示 10Y-2Y 利差
- **研报**：`macro_section` 纳入 FRED/Finnhub 摘要
- **文档**：`.github/API_KEYS_SETUP.md`

## 验证

合并后下一次 `Update Market Data` 工作流运行时应看到：

```
fred keyUsed: True status: ok items: 6
finnhub keyUsed: True status: ok items: ...
```

`data/macro.json` 中 `fred`、`finnhubNews`、`earningsCalendar` 字段应有数据。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62fa50dd-4422-4777-aa97-3de214aa93a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62fa50dd-4422-4777-aa97-3de214aa93a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

