### PR TITLE
feat: 投资大师风格荐股模块

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1636,3 +1636,136 @@ a:hover {
 #market-macro .panel__head h2 {
   margin: 0;
 }
+
+/* 荐股模式切换 */
+.reco-mode-tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.reco-mode-btn {
+  padding: 8px 16px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.5);
+  color: var(--text-muted);
+  font-size: 0.88rem;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+
+.reco-mode-btn:hover {
+  color: var(--text);
+  border-color: var(--accent);
+}
+
+.reco-mode-btn--active {
+  color: var(--text);
+  border-color: var(--accent);
+  background: rgba(56, 189, 248, 0.12);
+}
+
+/* 投资大师荐股 */
+.master-reco-grid {
+  display: grid;
+  gap: 20px;
+}
+
+.master-card {
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.master-card__style {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--accent);
+  letter-spacing: 0.04em;
+}
+
+.master-card__head h3 {
+  margin: 4px 0 0;
+  font-size: 1.15rem;
+}
+
+.master-card__en {
+  margin: 4px 0 0;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+
+.master-card__philosophy {
+  margin: 12px 0 0;
+  font-size: 0.92rem;
+  line-height: 1.65;
+  color: var(--text-muted);
+}
+
+.master-principles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 12px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.master-principles li {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.76rem;
+  background: rgba(56, 189, 248, 0.1);
+  color: #93c5fd;
+}
+
+.master-picks {
+  display: grid;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.master-pick h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.master-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 8px 0 0;
+}
+
+.master-metric {
+  padding: 4px 8px;
+  border-radius: 6px;
+  font-size: 0.78rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+}
+
+.master-metric em {
+  font-style: normal;
+  color: var(--text-muted);
+  margin-right: 4px;
+}
+
+.reco-plan--master dt {
+  color: #6ee7b7;
+}
+
+.master-empty {
+  margin: 0;
+  padding: 12px;
+  font-size: 0.88rem;
+}
+
+@media (min-width: 960px) {
+  .master-reco-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/data/market.json
+++ b/data/market.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-06-27T04:45:42+00:00",
+  "updatedAt": "2026-06-27T05:39:26+00:00",
   "summary": {
     "tracked": 6,
     "up": 0,
@@ -502,6 +502,14 @@
   ],
   "news": [
     {
+      "title": "2 Reasons Not to Invest in SpaceX -- and What to Buy Instead",
+      "link": "https://finance.yahoo.com/markets/stocks/articles/2-reasons-not-invest-spacex-052000915.html",
+      "publisher": "Motley Fool",
+      "related": "NVDA",
+      "publishedAt": "2026-06-27T05:20:00+00:00",
+      "summary": "It's best to let the hype die down before even considering investing in this stock."
+    },
+    {
       "title": "Nvidia's Market Cap Just Fell Below $5 Trillion. Here's Why It's a Buying Opportunity",
       "link": "https://finance.yahoo.com/markets/stocks/articles/nvidias-market-cap-just-fell-042500736.html",
       "publisher": "Motley Fool",
@@ -556,14 +564,6 @@
       "related": "NVDA",
       "publishedAt": "2026-06-27T02:50:00+00:00",
       "summary": "Meta just rolled out its cheapest pair of smart glasses yet. Will it make a difference?"
-    },
-    {
-      "title": "SpaceX Just Pulled Off the Largest IPO Ever. Here's Why Robinhood Might Be the Real Winner.",
-      "link": "https://finance.yahoo.com/markets/stocks/articles/spacex-just-pulled-off-largest-024600017.html",
-      "publisher": "Motley Fool",
-      "related": "NVDA",
-      "publishedAt": "2026-06-27T02:46:00+00:00",
-      "summary": "SpaceX's record IPO created a rare moment for retail brokerage platforms."
     },
     {
       "title": "Enphase Just Found A New Story To Tell",
@@ -1017,6 +1017,520 @@
         "breakout": false,
         "distToStopPct": 8.3,
         "distToTargetPct": 30.0
+      }
+    ]
+  },
+  "masterRecommendations": {
+    "version": "v1.0.0",
+    "strategy": "v1.0.0 投资大师风格荐股：基于 Yahoo 基本面与价格特征，模拟 6 位大师选股逻辑；每位大师推荐 2 只，与战术 v1.3 相互独立。",
+    "disclaimer": "大师风格荐股为规则化模拟，非真实人物操作建议；基本面数据可能有延迟或缺失，仅供研究，不构成投资建议。",
+    "masters": [
+      {
+        "id": "buffett",
+        "name": "沃伦·巴菲特",
+        "nameEn": "Warren Buffett",
+        "style": "价值投资",
+        "philosophy": "以合理价格买入具有宽阔护城河、稳定盈利能力的优质企业，长期持有。",
+        "principles": [
+          "护城河与品牌",
+          "ROE 持续高位",
+          "负债可控",
+          "管理层诚信",
+          "能力圈内投资"
+        ],
+        "holdingHorizon": "3–10 年+",
+        "picks": [
+          {
+            "symbol": "0700.HK",
+            "name": "腾讯控股",
+            "market": "港股",
+            "sector": "互联网",
+            "currency": "HKD",
+            "price": 411.8,
+            "matchScore": 100.0,
+            "signal": "buy",
+            "signalLabel": "符合风格 · 建议关注",
+            "reasons": [
+              "ROE 20.52% — 资本回报优秀，符合巴菲特护城河标准",
+              "PE 14.77 — 估值在能力圈合理区间",
+              "净利率 30.61% — 业务具备定价权",
+              "负债率可控，财务风险较低"
+            ],
+            "plan": {
+              "entry": "围绕 411.8 HKD 分批建仓，优先在回调至年线附近加仓；不追短线热点。",
+              "holding": "持有期 3–10 年+；关注 ROE 与护城河是否恶化。",
+              "risk": "基本面永久性损伤时退出；不因正常波动止损。",
+              "position": "单大师风格内建议 1–2 只核心标的；与战术策略、XRPS 战役仓独立配置。"
+            },
+            "metrics": {
+              "pe": 14.77,
+              "pb": 2.86,
+              "roe": 20.52,
+              "peg": 0.64,
+              "earningsGrowth": 22.9,
+              "profitMargins": 30.61,
+              "monthChangePct": -5.2,
+              "relativeStrength": 5.29,
+              "rangePosition": 0.0
+            }
+          },
+          {
+            "symbol": "300750.SZ",
+            "name": "宁德时代",
+            "market": "A股",
+            "sector": "新能源",
+            "currency": "CNY",
+            "price": 381.0,
+            "matchScore": 100.0,
+            "signal": "buy",
+            "signalLabel": "符合风格 · 建议关注",
+            "reasons": [
+              "ROE 25.36% — 资本回报优秀，符合巴菲特护城河标准",
+              "PE 21.73 — 估值在能力圈合理区间",
+              "净利率 16.87% — 业务具备定价权",
+              "负债率可控，财务风险较低"
+            ],
+            "plan": {
+              "entry": "围绕 381.0 CNY 分批建仓，优先在回调至年线附近加仓；不追短线热点。",
+              "holding": "持有期 3–10 年+；关注 ROE 与护城河是否恶化。",
+              "risk": "基本面永久性损伤时退出；不因正常波动止损。",
+              "position": "单大师风格内建议 1–2 只核心标的；与战术策略、XRPS 战役仓独立配置。"
+            },
+            "metrics": {
+              "pe": 21.73,
+              "pb": 4.83,
+              "roe": 25.36,
+              "peg": 0.49,
+              "earningsGrowth": 44.0,
+              "profitMargins": 16.87,
+              "monthChangePct": -8.15,
+              "relativeStrength": -6.53,
+              "rangePosition": 0.6
+            }
+          }
+        ]
+      },
+      {
+        "id": "graham",
+        "name": "本杰明·格雷厄姆",
+        "nameEn": "Benjamin Graham",
+        "style": "深度价值",
+        "philosophy": "安全边际是投资核心：在价格显著低于内在价值时分批买入，分散持有。",
+        "principles": [
+          "低 PE / 低 PB",
+          "安全边际",
+          "分散组合",
+          "避免投机",
+          "重视资产负债表"
+        ],
+        "holdingHorizon": "1–3 年",
+        "picks": [
+          {
+            "symbol": "600036.SS",
+            "name": "招商银行",
+            "market": "A股",
+            "sector": "银行",
+            "currency": "CNY",
+            "price": 36.0,
+            "matchScore": 100.0,
+            "signal": "buy",
+            "signalLabel": "符合风格 · 建议关注",
+            "reasons": [
+              "PE 6.3 — 深度价值区间，安全边际充足",
+              "PB 0.8 — 资产折价，经典格雷厄姆信号",
+              "价格处于 52 周区间下沿 — 悲观定价带来安全边际",
+              "股息率 8.37% — 提供下行保护垫"
+            ],
+            "plan": {
+              "entry": "仅在 36.0 附近或更低、且 PE/PB 维持低位时分批买入；拒绝「便宜但坏」的公司。",
+              "holding": "持有至估值修复至合理区间（1–3 年）。",
+              "risk": "负债恶化或盈利持续下滑时减仓；分散持有降低单一风险。",
+              "position": "单大师风格内建议 1–2 只核心标的；与战术策略、XRPS 战役仓独立配置。"
+            },
+            "metrics": {
+              "pe": 6.3,
+              "pb": 0.8,
+              "roe": 11.92,
+              "peg": 9.01,
+              "earningsGrowth": 0.7,
+              "profitMargins": 50.45,
+              "monthChangePct": -2.7,
+              "relativeStrength": -1.08,
+              "rangePosition": 0.01
+            }
+          },
+          {
+            "symbol": "601318.SS",
+            "name": "中国平安",
+            "market": "A股",
+            "sector": "保险",
+            "currency": "CNY",
+            "price": 47.23,
+            "matchScore": 100.0,
+            "signal": "buy",
+            "signalLabel": "符合风格 · 建议关注",
+            "reasons": [
+              "PE 6.51 — 深度价值区间，安全边际充足",
+              "PB 0.84 — 资产折价，经典格雷厄姆信号",
+              "价格处于 52 周区间下沿 — 悲观定价带来安全边际",
+              "股息率 5.72% — 提供下行保护垫"
+            ],
+            "plan": {
+              "entry": "仅在 47.23 附近或更低、且 PE/PB 维持低位时分批买入；拒绝「便宜但坏」的公司。",
+              "holding": "持有至估值修复至合理区间（1–3 年）。",
+              "risk": "负债恶化或盈利持续下滑时减仓；分散持有降低单一风险。",
+              "position": "单大师风格内建议 1–2 只核心标的；与战术策略、XRPS 战役仓独立配置。"
+            },
+            "metrics": {
+              "pe": 6.51,
+              "pb": 0.84,
+              "roe": 11.28,
+              "peg": null,
+              "earningsGrowth": -13.2,
+              "profitMargins": 13.94,
+              "monthChangePct": -8.36,
+              "relativeStrength": -6.74,
+              "rangePosition": 0.0
+            }
+          }
+        ]
+      },
+      {
+        "id": "lynch",
+        "name": "彼得·林奇",
+        "nameEn": "Peter Lynch",
+        "style": "成长合理价 GARP",
+        "philosophy": "投资你了解的公司；以 PEG 衡量成长是否被合理定价，偏好业绩可验证的成长股。",
+        "principles": [
+          "PEG < 1.5",
+          "业务可理解",
+          "盈利与营收增长",
+          "行业渗透空间",
+          "实地调研思维"
+        ],
+        "holdingHorizon": "1–5 年",
+        "picks": [
+          {
+            "symbol": "300750.SZ",
+            "name": "宁德时代",
+            "market": "A股",
+            "sector": "新能源",
+            "currency": "CNY",
+            "price": 381.0,
+            "matchScore": 96.0,
+            "signal": "buy",
+            "signalLabel": "符合风格 · 建议关注",
+            "reasons": [
+              "PEG 0.49 — 成长相对估值便宜，林奇「十倍股」潜力",
+              "盈利增速 44.0% — 成长故事可验证",
+              "营收增速 52.4% — 业务扩张持续",
+              "新能源 — 林奇偏好的可理解成长行业"
+            ],
+            "plan": {
+              "entry": "确认 PEG 与盈利增速匹配后，于 381.0 附近建仓；季度财报验证成长逻辑。",
+              "holding": "成长故事兑现或 PEG > 2 时考虑获利（1–5 年）。",
+              "risk": "盈利增速断崖式下滑时退出；不因短期回调轻易清仓。",
+              "position": "单大师风格内建议 1–2 只核心标的；与战术策略、XRPS 战役仓独立配置。"
+            },
+            "metrics": {
+              "pe": 21.73,
+              "pb": 4.83,
+              "roe": 25.36,
+              "peg": 0.49,
+              "earningsGrowth": 44.0,
+              "profitMargins": 16.87,
+              "monthChangePct": -8.15,
+              "relativeStrength": -6.53,
+              "rangePosition": 0.6
+            }
+          },
+          {
+            "symbol": "AMZN",
+            "name": "亚马逊",
+            "market": "美股",
+            "sector": "电商云计算",
+            "currency": "USD",
+            "price": 232.69,
+            "matchScore": 96.0,
+            "signal": "buy",
+            "signalLabel": "符合风格 · 建议关注",
+            "reasons": [
+              "PEG 0.42 — 成长相对估值便宜，林奇「十倍股」潜力",
+              "盈利增速 74.8% — 成长故事可验证",
+              "营收增速 16.6% — 业务扩张持续",
+              "电商云计算 — 林奇偏好的可理解成长行业"
+            ],
+            "plan": {
+              "entry": "确认 PEG 与盈利增速匹配后，于 232.69 附近建仓；季度财报验证成长逻辑。",
+              "holding": "成长故事兑现或 PEG > 2 时考虑获利（1–5 年）。",
+              "risk": "盈利增速断崖式下滑时退出；不因短期回调轻易清仓。",
+              "position": "单大师风格内建议 1–2 只核心标的；与战术策略、XRPS 战役仓独立配置。"
+            },
+            "metrics": {
+              "pe": 31.66,
+              "pb": 5.66,
+              "roe": 24.29,
+              "peg": 0.42,
+              "earningsGrowth": 74.8,
+              "profitMargins": 12.22,
+              "monthChangePct": -14.41,
+              "relativeStrength": -12.2,
+              "rangePosition": 0.44
+            }
+          }
+        ]
+      },
+      {
+        "id": "munger",
+        "name": "查理·芒格",
+        "nameEn": "Charlie Munger",
+        "style": "优质复利",
+        "philosophy": "以合理价格买入伟大的公司，胜过于以便宜价格买入平庸的公司。",
+        "principles": [
+          "高 ROE 复利",
+          "轻资产高毛利",
+          "逆向思维",
+          "少而精的决策",
+          "长期主义"
+        ],
+        "holdingHorizon": "5 年+",
+        "picks": [
+          {
+            "symbol": "600519.SS",
+            "name": "贵州茅台",
+            "market": "A股",
+            "sector": "白酒",
+            "currency": "CNY",
+            "price": 1168.63,
+            "matchScore": 100.0,
+            "signal": "buy",
+            "signalLabel": "符合风格 · 建议关注",
+            "reasons": [
+              "ROE 31.2% — 优质复利机器，芒格会长期持有",
+              "净利率 48.05% — 轻资产高毛利特征",
+              "低杠杆 — 符合芒格「避免愚蠢」原则",
+              "优质公司合理溢价可接受 — 以合理价格买伟大公司"
+            ],
+            "plan": {
+              "entry": "以 1168.63 为参考价，在优质复利逻辑未变前提下长期持有；好公司少动。",
+              "holding": "5 年+；与伟大企业共同成长。",
+              "risk": "商业模式被颠覆或管理层重大失误时退出。",
+              "position": "单大师风格内建议 1–2 只核心标的；与战术策略、XRPS 战役仓独立配置。"
+            },
+            "metrics": {
+              "pe": 17.7,
+              "pb": 5.4,
+              "roe": 31.2,
+              "peg": 9.83,
+              "earningsGrowth": 1.8,
+              "profitMargins": 48.05,
+              "monthChangePct": -8.19,
+              "relativeStrength": -6.57,
+              "rangePosition": 0.0
+            }
+          },
+          {
+            "symbol": "9992.HK",
+            "name": "泡泡玛特",
+            "market": "港股",
+            "sector": "潮玩零售",
+            "currency": "HKD",
+            "price": 158.5,
+            "matchScore": 100.0,
+            "signal": "buy",
+            "signalLabel": "符合风格 · 建议关注",
+            "reasons": [
+              "ROE 77.6% — 优质复利机器，芒格会长期持有",
+              "净利率 34.42% — 轻资产高毛利特征",
+              "低杠杆 — 符合芒格「避免愚蠢」原则",
+              "优质公司合理溢价可接受 — 以合理价格买伟大公司"
+            ],
+            "plan": {
+              "entry": "以 158.5 为参考价，在优质复利逻辑未变前提下长期持有；好公司少动。",
+              "holding": "5 年+；与伟大企业共同成长。",
+              "risk": "商业模式被颠覆或管理层重大失误时退出。",
+              "position": "单大师风格内建议 1–2 只核心标的；与战术策略、XRPS 战役仓独立配置。"
+            },
+            "metrics": {
+              "pe": 14.33,
+              "pb": 8.19,
+              "roe": 77.6,
+              "peg": 5.29,
+              "earningsGrowth": 2.71,
+              "profitMargins": 34.42,
+              "monthChangePct": 2.79,
+              "relativeStrength": 13.28,
+              "rangePosition": 0.09
+            }
+          }
+        ]
+      },
+      {
+        "id": "templeton",
+        "name": "约翰·邓普顿",
+        "nameEn": "John Templeton",
+        "style": "逆向投资",
+        "philosophy": "在最大悲观时买入，在最大乐观时卖出；关注被错杀的优质资产。",
+        "principles": [
+          "极度悲观时买入",
+          "52 周低位区间",
+          "基本面未恶化",
+          "全球视野",
+          "耐心持有"
+        ],
+        "holdingHorizon": "2–5 年",
+        "picks": [
+          {
+            "symbol": "1810.HK",
+            "name": "小米集团",
+            "market": "港股",
+            "sector": "消费电子",
+            "currency": "HKD",
+            "price": 21.42,
+            "matchScore": 96.0,
+            "signal": "buy",
+            "signalLabel": "符合风格 · 建议关注",
+            "reasons": [
+              "近一月 -24.58% — 市场悲观，邓普顿式逆向机会",
+              "近三月 -41.02% — 深度回调，关注基本面是否错杀",
+              "价格接近 52 周底部 — 「极度悲观时买入」",
+              "PE 11.9 — 悲观中仍有估值支撑"
+            ],
+            "plan": {
+              "entry": "市场极度悲观、价格 21.42 处于低位区间时逆向买入；需确认基本面未实质性恶化。",
+              "holding": "等待情绪修复（2–5 年）；耐心是关键。",
+              "risk": "若逆向逻辑被证伪（基本面崩塌），果断止损。",
+              "position": "单大师风格内建议 1–2 只核心标的；与战术策略、XRPS 战役仓独立配置。"
+            },
+            "metrics": {
+              "pe": 11.9,
+              "pb": 1.8,
+              "roe": 14.0,
+              "peg": null,
+              "earningsGrowth": -58.1,
+              "profitMargins": 7.96,
+              "monthChangePct": -24.58,
+              "relativeStrength": -14.09,
+              "rangePosition": 0.0
+            }
+          },
+          {
+            "symbol": "600519.SS",
+            "name": "贵州茅台",
+            "market": "A股",
+            "sector": "白酒",
+            "currency": "CNY",
+            "price": 1168.63,
+            "matchScore": 96.0,
+            "signal": "buy",
+            "signalLabel": "符合风格 · 建议关注",
+            "reasons": [
+              "近一月 -8.19% — 市场悲观，邓普顿式逆向机会",
+              "近三月 -17.21% — 深度回调，关注基本面是否错杀",
+              "价格接近 52 周底部 — 「极度悲观时买入」",
+              "PE 17.7 — 悲观中仍有估值支撑"
+            ],
+            "plan": {
+              "entry": "市场极度悲观、价格 1168.63 处于低位区间时逆向买入；需确认基本面未实质性恶化。",
+              "holding": "等待情绪修复（2–5 年）；耐心是关键。",
+              "risk": "若逆向逻辑被证伪（基本面崩塌），果断止损。",
+              "position": "单大师风格内建议 1–2 只核心标的；与战术策略、XRPS 战役仓独立配置。"
+            },
+            "metrics": {
+              "pe": 17.7,
+              "pb": 5.4,
+              "roe": 31.2,
+              "peg": 9.83,
+              "earningsGrowth": 1.8,
+              "profitMargins": 48.05,
+              "monthChangePct": -8.19,
+              "relativeStrength": -6.57,
+              "rangePosition": 0.0
+            }
+          }
+        ]
+      },
+      {
+        "id": "soros",
+        "name": "乔治·索罗斯",
+        "nameEn": "George Soros",
+        "style": "宏观趋势",
+        "philosophy": "反身性理论：趋势与认知相互强化；在宏观拐点与趋势确认时果断行动。",
+        "principles": [
+          "趋势确认",
+          "相对强度",
+          "宏观共振",
+          "快速止损",
+          "顺势而为"
+        ],
+        "holdingHorizon": "数周–数月",
+        "picks": [
+          {
+            "symbol": "AMD",
+            "name": "AMD",
+            "market": "美股",
+            "sector": "半导体",
+            "currency": "USD",
+            "price": 521.58,
+            "matchScore": 89.0,
+            "signal": "buy",
+            "signalLabel": "符合风格 · 建议关注",
+            "reasons": [
+              "相对强度 +7.46% — 跑赢大盘，宏观共振",
+              "均线多头排列 — 趋势交易确认",
+              "量比 1.64 — 资金参与度高",
+              "高 Beta 放大趋势 — 索罗斯式进攻配置"
+            ],
+            "plan": {
+              "entry": "趋势确认后于 521.58 附近顺势建仓；宏观与相对强度共振时加仓。",
+              "holding": "短中期趋势交易（数周–数月）；趋势破坏即减仓。",
+              "risk": "跌破关键均线或相对强度转负时严格止损；反身性逆转要快。",
+              "position": "单大师风格内建议 1–2 只核心标的；与战术策略、XRPS 战役仓独立配置。"
+            },
+            "metrics": {
+              "pe": 172.14,
+              "pb": 13.19,
+              "roe": 8.06,
+              "peg": 1.89,
+              "earningsGrowth": 91.2,
+              "profitMargins": 13.37,
+              "monthChangePct": 5.25,
+              "relativeStrength": 7.46,
+              "rangePosition": 0.9
+            }
+          },
+          {
+            "symbol": "688981.SS",
+            "name": "中芯国际",
+            "market": "A股",
+            "sector": "半导体",
+            "currency": "CNY",
+            "price": 148.76,
+            "matchScore": 63.0,
+            "signal": "watch",
+            "signalLabel": "部分符合 · 观察等待",
+            "reasons": [
+              "均线多头排列 — 趋势交易确认"
+            ],
+            "plan": {
+              "entry": "趋势确认后于 148.76 附近顺势建仓；宏观与相对强度共振时加仓。",
+              "holding": "短中期趋势交易（数周–数月）；趋势破坏即减仓。",
+              "risk": "跌破关键均线或相对强度转负时严格止损；反身性逆转要快。",
+              "position": "单大师风格内建议 1–2 只核心标的；与战术策略、XRPS 战役仓独立配置。"
+            },
+            "metrics": {
+              "pe": 243.87,
+              "pb": 8.49,
+              "roe": 2.64,
+              "peg": null,
+              "earningsGrowth": 0.0,
+              "profitMargins": 7.25,
+              "monthChangePct": 1.74,
+              "relativeStrength": 3.36,
+              "rangePosition": 0.86
+            }
+          }
+        ]
       }
     ]
   }

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/jsmind@0.8.7/es6/jsmind.js" defer></script>
   <script src="js/ai-mindmap.js" defer></script>
-  <script src="js/app.js?v=22" defer></script>
+  <script src="js/app.js?v=23" defer></script>
 </head>
 <body>
   <div class="app">
@@ -247,7 +247,11 @@
 
     <!-- 荐股 -->
     <section id="panel-reco" class="tab-panel" role="tabpanel" hidden>
-      <section class="panel panel--wide reco-section">
+      <nav class="reco-mode-tabs" id="reco-mode-tabs" role="tablist" aria-label="荐股模式">
+        <button type="button" class="reco-mode-btn reco-mode-btn--active" data-reco-mode="tactical" role="tab" aria-selected="true">战术 v1.3</button>
+        <button type="button" class="reco-mode-btn" data-reco-mode="masters" role="tab" aria-selected="false">投资大师</button>
+      </nav>
+      <section class="panel panel--wide reco-section" id="reco-tactical-panel">
         <div class="panel__head">
           <h2>今日荐股</h2>
           <p id="reco-strategy">战术实验 v1.3 · A股 / 港股 / 美股 各选 1 只</p>
@@ -255,7 +259,15 @@
         <div class="reco-cards" id="reco-cards"></div>
         <p class="reco-disclaimer" id="reco-disclaimer"></p>
       </section>
-      <section class="panel panel--wide">
+      <section class="panel panel--wide reco-section" id="reco-masters-panel" hidden>
+        <div class="panel__head">
+          <h2>投资大师风格荐股</h2>
+          <p id="master-reco-strategy">学习大师投资框架，按风格匹配候选池标的</p>
+        </div>
+        <div class="master-reco-grid" id="master-reco-grid"></div>
+        <p class="reco-disclaimer" id="master-reco-disclaimer"></p>
+      </section>
+      <section class="panel panel--wide" id="reco-scan-panel">
         <details class="candidate-scan" id="candidate-scan-wrap">
           <summary id="candidate-scan-summary">全市场评分扫描</summary>
           <div class="table-wrap">

--- a/js/app.js
+++ b/js/app.js
@@ -52,6 +52,7 @@ let macroData = null;
 let quoteMap = {};
 let quoteChangeMap = {};
 let activeTab = "cockpit";
+let recoMode = "tactical";
 let suppressTabRoute = false;
 const tabBundles = { paper: false, ai: false, reports: false };
 let historyDisplayLimit = HISTORY_DISPLAY_LIMIT;
@@ -251,6 +252,11 @@ function setupTabs() {
   });
   document.querySelectorAll("[data-goto-tab]").forEach((el) => {
     el.addEventListener("click", () => switchTab(el.dataset.gotoTab));
+  });
+
+  document.getElementById("reco-mode-tabs")?.addEventListener("click", (e) => {
+    const btn = e.target.closest(".reco-mode-btn");
+    if (btn?.dataset.recoMode) switchRecoMode(btn.dataset.recoMode);
   });
 
   window.addEventListener("popstate", () => {
@@ -840,6 +846,116 @@ function renderPickCard(pick, compact = false) {
       ${plan}
     </article>
   `;
+}
+
+function formatMasterMetric(key, val) {
+  if (val == null || val === "") return null;
+  if (key === "pe" || key === "pb" || key === "peg") return formatNumber(val, 2);
+  if (key === "roe" || key === "profitMargins" || key === "earningsGrowth") return `${formatNumber(val, 1)}%`;
+  if (key === "monthChangePct" || key === "relativeStrength") return formatPct(val);
+  if (key === "rangePosition") return `${Math.round(val * 100)}%`;
+  return String(val);
+}
+
+function renderMasterPickCard(pick) {
+  const metrics = pick.metrics || {};
+  const metricLabels = {
+    pe: "PE",
+    pb: "PB",
+    roe: "ROE",
+    peg: "PEG",
+    earningsGrowth: "盈利增速",
+    profitMargins: "净利率",
+    monthChangePct: "近一月",
+    relativeStrength: "相对强度",
+    rangePosition: "52周区间",
+  };
+  const metricHtml = Object.entries(metricLabels)
+    .map(([key, label]) => {
+      const val = formatMasterMetric(key, metrics[key]);
+      return val != null ? `<span class="master-metric"><em>${label}</em> ${val}</span>` : "";
+    })
+    .filter(Boolean)
+    .join("");
+
+  return `
+    <article class="master-pick reco-card reco-card--${pick.signal}">
+      <div class="reco-card__top">
+        <div>
+          <div class="reco-card__tags">
+            <span class="reco-market reco-market--${marketClass(pick.market)}">${pick.market}</span>
+          </div>
+          <h4>${pick.name}</h4>
+          <p class="stock-card__symbol">${pick.symbol} · ${pick.sector || ""}</p>
+        </div>
+        <div class="reco-card__badge-box">
+          <span class="reco-badge reco-badge--${pick.signal}">${pick.signalLabel}</span>
+          <span class="reco-score">匹配 ${pick.matchScore}</span>
+        </div>
+      </div>
+      <p class="stock-card__price">${formatNumber(pick.price)} <span>${pick.currency || ""}</span></p>
+      ${metricHtml ? `<div class="master-metrics">${metricHtml}</div>` : ""}
+      <ul class="reco-reasons">${(pick.reasons || []).map((r) => `<li>${r}</li>`).join("")}</ul>
+      <dl class="reco-plan reco-plan--master">
+        <div><dt>买入</dt><dd>${pick.plan?.entry || "—"}</dd></div>
+        <div><dt>持有</dt><dd>${pick.plan?.holding || "—"}</dd></div>
+        <div><dt>风控</dt><dd>${pick.plan?.risk || "—"}</dd></div>
+        <div><dt>仓位</dt><dd>${pick.plan?.position || "—"}</dd></div>
+      </dl>
+    </article>
+  `;
+}
+
+function renderMasterRecommendations(data) {
+  const grid = document.getElementById("master-reco-grid");
+  const strategyEl = document.getElementById("master-reco-strategy");
+  const disclaimerEl = document.getElementById("master-reco-disclaimer");
+  if (!grid) return;
+
+  if (!data?.masters?.length) {
+    grid.innerHTML = '<p class="empty">大师风格荐股数据加载中…</p>';
+    return;
+  }
+
+  if (strategyEl && data.strategy) strategyEl.textContent = data.strategy;
+  if (disclaimerEl) disclaimerEl.textContent = data.disclaimer || "";
+
+  grid.innerHTML = data.masters
+    .map((master) => {
+      const picksHtml = master.picks?.length
+        ? master.picks.map((p) => renderMasterPickCard(p)).join("")
+        : '<p class="empty master-empty">当前候选池暂无符合该风格的标的</p>';
+      return `
+        <article class="master-card" id="master-${master.id}">
+          <header class="master-card__head">
+            <div>
+              <p class="master-card__style">${master.style}</p>
+              <h3>${master.name}</h3>
+              <p class="master-card__en">${master.nameEn || ""} · 持有 ${master.holdingHorizon || "—"}</p>
+            </div>
+          </header>
+          <p class="master-card__philosophy">${master.philosophy || ""}</p>
+          <ul class="master-principles">${(master.principles || []).map((p) => `<li>${p}</li>`).join("")}</ul>
+          <div class="master-picks">${picksHtml}</div>
+        </article>
+      `;
+    })
+    .join("");
+}
+
+function switchRecoMode(mode) {
+  recoMode = mode;
+  document.querySelectorAll(".reco-mode-btn").forEach((btn) => {
+    const active = btn.dataset.recoMode === mode;
+    btn.classList.toggle("reco-mode-btn--active", active);
+    btn.setAttribute("aria-selected", active ? "true" : "false");
+  });
+  const tactical = document.getElementById("reco-tactical-panel");
+  const masters = document.getElementById("reco-masters-panel");
+  const scan = document.getElementById("reco-scan-panel");
+  if (tactical) tactical.hidden = mode !== "tactical";
+  if (masters) masters.hidden = mode !== "masters";
+  if (scan) scan.hidden = mode !== "tactical";
 }
 
 function renderRecommendations(reco, containerId = "reco-cards", compact = false) {
@@ -3095,6 +3211,8 @@ function applyData(data) {
   renderCockpitMarkets(data.marketRadar);
   renderRecommendations(data.recommendations, "cockpit-picks", true);
   renderRecommendations(data.recommendations, "reco-cards", false);
+  renderMasterRecommendations(data.masterRecommendations);
+  switchRecoMode(recoMode);
   renderCockpitIndices(data.indices);
 
   yahooNews = data.news || [];

--- a/scripts/fetch_data.py
+++ b/scripts/fetch_data.py
@@ -77,6 +77,7 @@ from strategy_scoring import (
     sma,
 )
 from reco_signals import update_reco_signals
+from strategy_masters import build_master_recommendations
 
 MAX_PICKS_PER_MARKET = 1
 MARKETS = ("A股", "港股", "美股")
@@ -554,6 +555,7 @@ def main() -> None:
     news = fetch_news()
     now = datetime.now(timezone.utc).astimezone()
     recommendations, quote_map, change_map = build_recommendations(now)
+    master_recommendations = build_master_recommendations(CANDIDATES)
     for item in stocks:
         if item.get("symbol") and item.get("changePct") is not None:
             change_map[item["symbol"]] = item["changePct"]
@@ -568,6 +570,7 @@ def main() -> None:
         "stocks": stocks,
         "news": news,
         "recommendations": recommendations,
+        "masterRecommendations": master_recommendations,
     }
 
     OUTPUT_FILE.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")

--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -293,6 +293,43 @@ def tactical_section(market: dict | None, signals: dict | None) -> str:
     return "\n\n".join(parts)
 
 
+def master_reco_section(market: dict | None) -> str:
+    data = (market or {}).get("masterRecommendations") or {}
+    masters = data.get("masters") or []
+    if not masters:
+        return "大师风格荐股数据暂缺。"
+
+    parts = [
+        f"基于候选池基本面与价格特征，模拟 **{len(masters)}** 位投资大师选股框架（{data.get('version', 'v1.0')}）。"
+    ]
+    for master in masters:
+        picks = master.get("picks") or []
+        parts.append(f"\n### {master.get('name')} · {master.get('style')}")
+        parts.append(f"*{master.get('philosophy', '')}*")
+        if not picks:
+            parts.append("- 当前无达标标的")
+            continue
+        for p in picks:
+            m = p.get("metrics") or {}
+            metric_bits = []
+            if m.get("pe") is not None:
+                metric_bits.append(f"PE {fmt_num(m['pe'], 1)}")
+            if m.get("peg") is not None:
+                metric_bits.append(f"PEG {fmt_num(m['peg'], 2)}")
+            if m.get("roe") is not None:
+                metric_bits.append(f"ROE {fmt_num(m['roe'], 1)}%")
+            metrics_s = " · ".join(metric_bits) if metric_bits else "—"
+            parts.append(
+                f"- **{p.get('name')}**（{p.get('market')}）| 匹配 {p.get('matchScore')} | "
+                f"{p.get('signalLabel')} | {metrics_s}"
+            )
+            if p.get("reasons"):
+                parts.append(f"  - {'；'.join(p['reasons'][:2])}")
+
+    parts.append(f"\n*{data.get('disclaimer', '')}*")
+    return "\n\n".join(parts)
+
+
 def news_section(market: dict | None, wencai: dict | None) -> str:
     items = []
     for n in (market or {}).get("news") or []:
@@ -548,22 +585,29 @@ def build_report(slot: str, now_bjt: datetime | None = None) -> tuple[str, dict]
 
 ---
 
-## 四、资讯与主题线索
+## 四、投资大师风格荐股
+
+{master_reco_section(market)}
+
+---
+
+## 五、资讯与主题线索
 
 {news_section(market, wencai)}
 
 ---
 
-## 五、风险提示
+## 六、风险提示
 
 1. 本报告基于公开行情与规则化模型，**不构成投资建议**；战术实验与战役 XRPS 为相互独立的两套体系，请勿混仓决策。  
 2. 港股 / 美股存在汇率、流动性及隔夜缺口风险；A股须关注涨跌停制度下的执行偏差。  
 3. 问财等非官方数据源可能延迟或缓存；涨停榜等情绪指标需与实时盘口交叉验证。  
 4. 模拟盘收益不代表未来表现；连阴月加仓逻辑基于历史回测，极端宏观冲击下可能失效。
+5. 大师风格荐股为规则化模拟，非真实人物操作建议；基本面数据可能有延迟或缺失。
 
 ---
 
-## 六、本时段关注清单
+## 七、本时段关注清单
 
 {watchlist(slot, market, paper, signals, diag)}
 

--- a/scripts/strategy_masters.py
+++ b/scripts/strategy_masters.py
@@ -1,0 +1,597 @@
+"""投资大师风格荐股 — 基于公开基本面与价格特征的多风格打分。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+import yfinance as yf
+
+from strategy_scoring import MARKET_BENCHMARKS, pct_change, sma
+
+MASTER_VERSION = "v1.0.0"
+PICKS_PER_MASTER = 2
+MIN_MATCH_SCORE = 48
+
+
+@dataclass(frozen=True)
+class MasterProfile:
+    id: str
+    name: str
+    name_en: str
+    style: str
+    philosophy: str
+    principles: tuple[str, ...]
+    holding: str
+
+
+MASTER_PROFILES: tuple[MasterProfile, ...] = (
+    MasterProfile(
+        id="buffett",
+        name="沃伦·巴菲特",
+        name_en="Warren Buffett",
+        style="价值投资",
+        philosophy="以合理价格买入具有宽阔护城河、稳定盈利能力的优质企业，长期持有。",
+        principles=("护城河与品牌", "ROE 持续高位", "负债可控", "管理层诚信", "能力圈内投资"),
+        holding="3–10 年+",
+    ),
+    MasterProfile(
+        id="graham",
+        name="本杰明·格雷厄姆",
+        name_en="Benjamin Graham",
+        style="深度价值",
+        philosophy="安全边际是投资核心：在价格显著低于内在价值时分批买入，分散持有。",
+        principles=("低 PE / 低 PB", "安全边际", "分散组合", "避免投机", "重视资产负债表"),
+        holding="1–3 年",
+    ),
+    MasterProfile(
+        id="lynch",
+        name="彼得·林奇",
+        name_en="Peter Lynch",
+        style="成长合理价 GARP",
+        philosophy="投资你了解的公司；以 PEG 衡量成长是否被合理定价，偏好业绩可验证的成长股。",
+        principles=("PEG < 1.5", "业务可理解", "盈利与营收增长", "行业渗透空间", "实地调研思维"),
+        holding="1–5 年",
+    ),
+    MasterProfile(
+        id="munger",
+        name="查理·芒格",
+        name_en="Charlie Munger",
+        style="优质复利",
+        philosophy="以合理价格买入伟大的公司，胜过于以便宜价格买入平庸的公司。",
+        principles=("高 ROE 复利", "轻资产高毛利", "逆向思维", "少而精的决策", "长期主义"),
+        holding="5 年+",
+    ),
+    MasterProfile(
+        id="templeton",
+        name="约翰·邓普顿",
+        name_en="John Templeton",
+        style="逆向投资",
+        philosophy="在最大悲观时买入，在最大乐观时卖出；关注被错杀的优质资产。",
+        principles=("极度悲观时买入", "52 周低位区间", "基本面未恶化", "全球视野", "耐心持有"),
+        holding="2–5 年",
+    ),
+    MasterProfile(
+        id="soros",
+        name="乔治·索罗斯",
+        name_en="George Soros",
+        style="宏观趋势",
+        philosophy="反身性理论：趋势与认知相互强化；在宏观拐点与趋势确认时果断行动。",
+        principles=("趋势确认", "相对强度", "宏观共振", "快速止损", "顺势而为"),
+        holding="数周–数月",
+    ),
+)
+
+
+def _norm_ratio(val: float | None, as_pct: bool = True) -> float | None:
+    if val is None:
+        return None
+    try:
+        v = float(val)
+    except (TypeError, ValueError):
+        return None
+    if as_pct and 0 < abs(v) <= 1.5:
+        return round(v * 100, 2)
+    return round(v, 2)
+
+
+def _clamp_score(score: float) -> float:
+    return round(max(0.0, min(100.0, score)), 1)
+
+
+def fetch_candidate_context(symbol: str, meta: dict) -> dict | None:
+    """拉取单只候选的基本面 + 价格上下文。"""
+    market = meta.get("market", "美股")
+    try:
+        ticker = yf.Ticker(symbol)
+        hist = ticker.history(period="2y", interval="1d")
+        info = ticker.info or {}
+    except Exception:
+        return None
+
+    if hist.empty:
+        return None
+
+    closes = [float(v) for v in hist["Close"].dropna().tolist()]
+    highs = [float(v) for v in hist["High"].dropna().tolist()]
+    lows = [float(v) for v in hist["Low"].dropna().tolist()]
+    volumes = [float(v) for v in hist["Volume"].dropna().tolist()]
+    price = closes[-1]
+
+    week_ago = closes[-6] if len(closes) >= 6 else None
+    month_ago = closes[-22] if len(closes) >= 22 else None
+    quarter_ago = closes[-66] if len(closes) >= 66 else None
+
+    hi52 = info.get("fiftyTwoWeekHigh") or (max(highs[-252:]) if len(highs) >= 20 else None)
+    lo52 = info.get("fiftyTwoWeekLow") or (min(lows[-252:]) if len(lows) >= 20 else None)
+    pct_from_high = None
+    pct_from_low = None
+    if hi52 and lo52 and hi52 > lo52:
+        pct_from_high = round((price - hi52) / hi52 * 100, 2)
+        pct_from_low = round((price - lo52) / lo52 * 100, 2)
+        range_pos = (price - lo52) / (hi52 - lo52)
+    else:
+        range_pos = 0.5
+
+    ma200 = sma(closes, 200)
+    ma50 = sma(closes, 50)
+    above_ma200 = price >= ma200 if ma200 else None
+    above_ma50 = price >= ma50 if ma50 else None
+
+    bench_symbol = MARKET_BENCHMARKS.get(market)
+    rel_strength = None
+    if bench_symbol:
+        try:
+            bench_closes = [
+                float(v)
+                for v in yf.Ticker(bench_symbol).history(period="6mo", interval="1d")["Close"].dropna().tolist()
+            ]
+            if len(bench_closes) >= 22 and month_ago:
+                stock_m = pct_change(price, month_ago)
+                bench_m = pct_change(bench_closes[-1], bench_closes[-22])
+                if stock_m is not None and bench_m is not None:
+                    rel_strength = round(stock_m - bench_m, 2)
+        except Exception:
+            pass
+
+    avg_vol = sum(volumes[-20:]) / 20 if len(volumes) >= 20 else None
+    vol_ratio = round(volumes[-1] / avg_vol, 2) if avg_vol and avg_vol > 0 else None
+
+    pe = info.get("trailingPE") or info.get("forwardPE")
+    pb = info.get("priceToBook")
+    roe = _norm_ratio(info.get("returnOnEquity"))
+    margins = _norm_ratio(info.get("profitMargins"))
+    debt = info.get("debtToEquity")
+    rev_growth = _norm_ratio(info.get("revenueGrowth"))
+    earn_growth = _norm_ratio(info.get("earningsGrowth"))
+    div_yield = _norm_ratio(info.get("dividendYield"), as_pct=False)
+    if div_yield is not None and div_yield < 1:
+        div_yield = round(div_yield * 100, 2)
+    beta = info.get("beta")
+    mcap = info.get("marketCap")
+
+    peg = None
+    if pe and earn_growth and earn_growth > 0:
+        peg = round(pe / earn_growth, 2)
+
+    return {
+        "symbol": symbol,
+        "name": meta["name"],
+        "market": market,
+        "sector": meta.get("sector"),
+        "currency": meta.get("currency", "USD"),
+        "price": round(price, 2),
+        "monthChangePct": pct_change(price, month_ago),
+        "quarterChangePct": pct_change(price, quarter_ago),
+        "weekChangePct": pct_change(price, week_ago),
+        "pctFrom52wHigh": pct_from_high,
+        "pctFrom52wLow": pct_from_low,
+        "rangePosition": round(range_pos, 2),
+        "aboveMa200": above_ma200,
+        "aboveMa50": above_ma50,
+        "relativeStrength": rel_strength,
+        "volumeRatio": vol_ratio,
+        "pe": round(pe, 2) if pe else None,
+        "pb": round(pb, 2) if pb else None,
+        "roe": roe,
+        "profitMargins": margins,
+        "debtToEquity": round(debt, 2) if debt is not None else None,
+        "revenueGrowth": rev_growth,
+        "earningsGrowth": earn_growth,
+        "peg": peg,
+        "dividendYield": div_yield,
+        "beta": round(beta, 2) if beta is not None else None,
+        "marketCap": mcap,
+    }
+
+
+def _score_buffett(ctx: dict) -> tuple[float, list[str]]:
+    score = 50.0
+    reasons: list[str] = []
+
+    roe = ctx.get("roe")
+    if roe is not None:
+        if roe >= 20:
+            score += 18
+            reasons.append(f"ROE {roe}% — 资本回报优秀，符合巴菲特护城河标准")
+        elif roe >= 12:
+            score += 10
+            reasons.append(f"ROE {roe}% — 盈利能力稳健")
+        else:
+            score -= 8
+
+    pe = ctx.get("pe")
+    if pe is not None:
+        if pe <= 25:
+            score += 12
+            reasons.append(f"PE {pe} — 估值在能力圈合理区间")
+        elif pe <= 35:
+            score += 4
+        else:
+            score -= 10
+            reasons.append(f"PE {pe} 偏高 — 需更大安全边际才符合巴菲特买价")
+
+    margins = ctx.get("profitMargins")
+    if margins is not None and margins >= 15:
+        score += 8
+        reasons.append(f"净利率 {margins}% — 业务具备定价权")
+
+    debt = ctx.get("debtToEquity")
+    if debt is not None:
+        if debt < 80:
+            score += 6
+            reasons.append("负债率可控，财务风险较低")
+        elif debt > 150:
+            score -= 8
+
+    if ctx.get("aboveMa200") is True and ctx.get("rangePosition", 1) < 0.75:
+        score += 8
+        reasons.append("长期趋势向上且未严重高估 — 可分批建仓")
+    elif ctx.get("rangePosition", 1) < 0.35:
+        score += 10
+        reasons.append("价格接近 52 周低位 — 优质资产回调机会")
+
+    mcap = ctx.get("marketCap")
+    if mcap and mcap >= 50e9:
+        score += 4
+        reasons.append("龙头体量，业务护城河更易验证")
+
+    return _clamp_score(score), reasons[:4]
+
+
+def _score_graham(ctx: dict) -> tuple[float, list[str]]:
+    score = 45.0
+    reasons: list[str] = []
+
+    pe = ctx.get("pe")
+    if pe is not None:
+        if pe < 12:
+            score += 22
+            reasons.append(f"PE {pe} — 深度价值区间，安全边际充足")
+        elif pe < 18:
+            score += 12
+            reasons.append(f"PE {pe} — 低于市场平均，具备安全边际")
+        elif pe > 30:
+            score -= 15
+
+    pb = ctx.get("pb")
+    if pb is not None:
+        if pb < 1.2:
+            score += 18
+            reasons.append(f"PB {pb} — 资产折价，经典格雷厄姆信号")
+        elif pb < 2:
+            score += 8
+        elif pb > 5:
+            score -= 8
+
+    rp = ctx.get("rangePosition")
+    if rp is not None and rp < 0.3:
+        score += 12
+        reasons.append("价格处于 52 周区间下沿 — 悲观定价带来安全边际")
+    elif rp is not None and rp < 0.5:
+        score += 6
+
+    div = ctx.get("dividendYield")
+    if div is not None and div >= 2:
+        score += 5
+        reasons.append(f"股息率 {div}% — 提供下行保护垫")
+
+    debt = ctx.get("debtToEquity")
+    if debt is not None and debt > 200:
+        score -= 10
+        reasons.append("负债过高 — 不符合格雷厄姆防御型标准")
+
+    return _clamp_score(score), reasons[:4]
+
+
+def _score_lynch(ctx: dict) -> tuple[float, list[str]]:
+    score = 48.0
+    reasons: list[str] = []
+
+    peg = ctx.get("peg")
+    earn_g = ctx.get("earningsGrowth")
+    rev_g = ctx.get("revenueGrowth")
+    pe = ctx.get("pe")
+
+    if peg is not None:
+        if peg < 1:
+            score += 22
+            reasons.append(f"PEG {peg} — 成长相对估值便宜，林奇「十倍股」潜力")
+        elif peg < 1.5:
+            score += 14
+            reasons.append(f"PEG {peg} — 成长合理价，符合 GARP 框架")
+        elif peg > 2.5:
+            score -= 10
+
+    if earn_g is not None:
+        if earn_g >= 20:
+            score += 12
+            reasons.append(f"盈利增速 {earn_g}% — 成长故事可验证")
+        elif earn_g >= 10:
+            score += 6
+        elif earn_g < 0:
+            score -= 12
+
+    if rev_g is not None and rev_g >= 10:
+        score += 6
+        reasons.append(f"营收增速 {rev_g}% — 业务扩张持续")
+
+    if pe is not None and pe < 35 and earn_g and earn_g > 15:
+        score += 4
+
+    sector = ctx.get("sector") or ""
+    if sector in ("半导体", "新能源", "互联网", "软件云计算", "电商云计算"):
+        score += 4
+        reasons.append(f"{sector} — 林奇偏好的可理解成长行业")
+
+    return _clamp_score(score), reasons[:4]
+
+
+def _score_munger(ctx: dict) -> tuple[float, list[str]]:
+    score = 50.0
+    reasons: list[str] = []
+
+    roe = ctx.get("roe")
+    if roe is not None:
+        if roe >= 25:
+            score += 20
+            reasons.append(f"ROE {roe}% — 优质复利机器，芒格会长期持有")
+        elif roe >= 18:
+            score += 12
+        else:
+            score -= 6
+
+    margins = ctx.get("profitMargins")
+    if margins is not None and margins >= 25:
+        score += 14
+        reasons.append(f"净利率 {margins}% — 轻资产高毛利特征")
+    elif margins is not None and margins >= 15:
+        score += 6
+
+    debt = ctx.get("debtToEquity")
+    if debt is not None and debt < 60:
+        score += 8
+        reasons.append("低杠杆 — 符合芒格「避免愚蠢」原则")
+
+    pe = ctx.get("pe")
+    if pe is not None and roe and roe >= 20:
+        if pe <= 40:
+            score += 8
+            reasons.append("优质公司合理溢价可接受 — 以合理价格买伟大公司")
+        else:
+            score -= 4
+
+    if ctx.get("aboveMa200") is True:
+        score += 6
+        reasons.append("长期趋势完好 — 复利故事未被破坏")
+
+    return _clamp_score(score), reasons[:4]
+
+
+def _score_templeton(ctx: dict) -> tuple[float, list[str]]:
+    score = 42.0
+    reasons: list[str] = []
+
+    month = ctx.get("monthChangePct")
+    quarter = ctx.get("quarterChangePct")
+    rp = ctx.get("rangePosition")
+
+    if month is not None and month < -8:
+        score += 16
+        reasons.append(f"近一月 {month}% — 市场悲观，邓普顿式逆向机会")
+    elif month is not None and month < -3:
+        score += 8
+    elif month is not None and month > 15:
+        score -= 10
+
+    if quarter is not None and quarter < -15:
+        score += 10
+        reasons.append(f"近三月 {quarter}% — 深度回调，关注基本面是否错杀")
+
+    if rp is not None and rp < 0.25:
+        score += 14
+        reasons.append("价格接近 52 周底部 — 「极度悲观时买入」")
+    elif rp is not None and rp < 0.4:
+        score += 8
+
+    pe = ctx.get("pe")
+    if pe is not None and pe < 25:
+        score += 8
+        reasons.append(f"PE {pe} — 悲观中仍有估值支撑")
+    elif pe is not None and pe > 50:
+        score -= 8
+        reasons.append("估值仍高 — 可能只是成长回落而非错杀")
+
+    roe = ctx.get("roe")
+    if roe is not None and roe >= 12:
+        score += 6
+        reasons.append("盈利能力仍在 — 逆向不是接飞刀")
+
+    return _clamp_score(score), reasons[:4]
+
+
+def _score_soros(ctx: dict) -> tuple[float, list[str]]:
+    score = 45.0
+    reasons: list[str] = []
+
+    month = ctx.get("monthChangePct")
+    rs = ctx.get("relativeStrength")
+    vol = ctx.get("volumeRatio")
+
+    if month is not None:
+        if month >= 8:
+            score += 16
+            reasons.append(f"近一月 +{month}% — 趋势强劲，反身性正反馈")
+        elif month >= 3:
+            score += 10
+        elif month < -5:
+            score -= 6
+
+    if rs is not None:
+        if rs >= 5:
+            score += 14
+            reasons.append(f"相对强度 +{rs}% — 跑赢大盘，宏观共振")
+        elif rs >= 2:
+            score += 8
+        elif rs < -5:
+            score -= 8
+
+    if ctx.get("aboveMa50") is True and ctx.get("aboveMa200") is True:
+        score += 10
+        reasons.append("均线多头排列 — 趋势交易确认")
+
+    if vol is not None and vol >= 1.3:
+        score += 6
+        reasons.append(f"量比 {vol} — 资金参与度高")
+
+    beta = ctx.get("beta")
+    if beta is not None and beta >= 1.1 and month and month > 0:
+        score += 4
+        reasons.append("高 Beta 放大趋势 — 索罗斯式进攻配置")
+
+    return _clamp_score(score), reasons[:4]
+
+
+SCORERS: dict[str, Callable[[dict], tuple[float, list[str]]]] = {
+    "buffett": _score_buffett,
+    "graham": _score_graham,
+    "lynch": _score_lynch,
+    "munger": _score_munger,
+    "templeton": _score_templeton,
+    "soros": _score_soros,
+}
+
+
+def _signal_from_score(score: float) -> tuple[str, str]:
+    if score >= 72:
+        return "buy", "符合风格 · 建议关注"
+    if score >= 58:
+        return "watch", "部分符合 · 观察等待"
+    return "watch", "弱匹配 · 仅供参考"
+
+
+def _build_plan(profile: MasterProfile, ctx: dict, score: float) -> dict:
+    price = ctx.get("price")
+    currency = ctx.get("currency", "")
+    if profile.id == "buffett":
+        entry = f"围绕 {price} {currency} 分批建仓，优先在回调至年线附近加仓；不追短线热点。"
+        holding = f"持有期 {profile.holding}；关注 ROE 与护城河是否恶化。"
+        risk = "基本面永久性损伤时退出；不因正常波动止损。"
+    elif profile.id == "graham":
+        entry = f"仅在 {price} 附近或更低、且 PE/PB 维持低位时分批买入；拒绝「便宜但坏」的公司。"
+        holding = f"持有至估值修复至合理区间（{profile.holding}）。"
+        risk = "负债恶化或盈利持续下滑时减仓；分散持有降低单一风险。"
+    elif profile.id == "lynch":
+        entry = f"确认 PEG 与盈利增速匹配后，于 {price} 附近建仓；季度财报验证成长逻辑。"
+        holding = f"成长故事兑现或 PEG > 2 时考虑获利（{profile.holding}）。"
+        risk = "盈利增速断崖式下滑时退出；不因短期回调轻易清仓。"
+    elif profile.id == "munger":
+        entry = f"以 {price} 为参考价，在优质复利逻辑未变前提下长期持有；好公司少动。"
+        holding = f"{profile.holding}；与伟大企业共同成长。"
+        risk = "商业模式被颠覆或管理层重大失误时退出。"
+    elif profile.id == "templeton":
+        entry = f"市场极度悲观、价格 {price} 处于低位区间时逆向买入；需确认基本面未实质性恶化。"
+        holding = f"等待情绪修复（{profile.holding}）；耐心是关键。"
+        risk = "若逆向逻辑被证伪（基本面崩塌），果断止损。"
+    else:
+        entry = f"趋势确认后于 {price} 附近顺势建仓；宏观与相对强度共振时加仓。"
+        holding = f"短中期趋势交易（{profile.holding.strip()}）；趋势破坏即减仓。"
+        risk = "跌破关键均线或相对强度转负时严格止损；反身性逆转要快。"
+
+    position = "单大师风格内建议 1–2 只核心标的；与战术策略、XRPS 战役仓独立配置。"
+    return {"entry": entry, "holding": holding, "risk": risk, "position": position}
+
+
+def _pick_row(profile: MasterProfile, ctx: dict, score: float, reasons: list[str]) -> dict:
+    signal, label = _signal_from_score(score)
+    return {
+        "symbol": ctx["symbol"],
+        "name": ctx["name"],
+        "market": ctx["market"],
+        "sector": ctx.get("sector"),
+        "currency": ctx.get("currency"),
+        "price": ctx.get("price"),
+        "matchScore": score,
+        "signal": signal,
+        "signalLabel": label,
+        "reasons": reasons,
+        "plan": _build_plan(profile, ctx, score),
+        "metrics": {
+            "pe": ctx.get("pe"),
+            "pb": ctx.get("pb"),
+            "roe": ctx.get("roe"),
+            "peg": ctx.get("peg"),
+            "earningsGrowth": ctx.get("earningsGrowth"),
+            "profitMargins": ctx.get("profitMargins"),
+            "monthChangePct": ctx.get("monthChangePct"),
+            "relativeStrength": ctx.get("relativeStrength"),
+            "rangePosition": ctx.get("rangePosition"),
+        },
+    }
+
+
+def build_master_recommendations(candidates: dict) -> dict:
+    contexts: list[dict] = []
+    for symbol, meta in candidates.items():
+        ctx = fetch_candidate_context(symbol, meta)
+        if ctx:
+            contexts.append(ctx)
+
+    masters_out = []
+    for profile in MASTER_PROFILES:
+        scorer = SCORERS[profile.id]
+        ranked: list[tuple[float, dict, list[str]]] = []
+        for ctx in contexts:
+            score, reasons = scorer(ctx)
+            if score >= MIN_MATCH_SCORE:
+                ranked.append((score, ctx, reasons))
+        ranked.sort(key=lambda x: (-x[0], x[1]["symbol"]))
+
+        picks = [_pick_row(profile, ctx, score, reasons) for score, ctx, reasons in ranked[:PICKS_PER_MASTER]]
+
+        masters_out.append(
+            {
+                "id": profile.id,
+                "name": profile.name,
+                "nameEn": profile.name_en,
+                "style": profile.style,
+                "philosophy": profile.philosophy,
+                "principles": list(profile.principles),
+                "holdingHorizon": profile.holding,
+                "picks": picks,
+            }
+        )
+
+    return {
+        "version": MASTER_VERSION,
+        "strategy": (
+            f"{MASTER_VERSION} 投资大师风格荐股："
+            f"基于 Yahoo 基本面与价格特征，模拟 {len(MASTER_PROFILES)} 位大师选股逻辑；"
+            f"每位大师推荐 {PICKS_PER_MASTER} 只，与战术 v1.3 相互独立。"
+        ),
+        "disclaimer": (
+            "大师风格荐股为规则化模拟，非真实人物操作建议；"
+            "基本面数据可能有延迟或缺失，仅供研究，不构成投资建议。"
+        ),
+        "masters": masters_out,
+    }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

在现有战术 v1.3 荐股之外，新增 **投资大师风格荐股**：学习 6 位大师的投资框架，从候选池中按各自风格匹配并推荐标的。

## 六位大师

| 大师 | 风格 | 核心逻辑 |
|------|------|----------|
| 巴菲特 | 价值投资 | 高 ROE、合理 PE、护城河（净利率）、低负债 |
| 格雷厄姆 | 深度价值 | 低 PE/PB、52 周低位、股息保护 |
| 彼得·林奇 | GARP | PEG、盈利/营收增速、可理解成长行业 |
| 芒格 | 优质复利 | 高 ROE + 高毛利、低杠杆、长期趋势 |
| 邓普顿 | 逆向投资 | 近月/近季回调、52 周底部、基本面未崩 |
| 索罗斯 | 宏观趋势 | 动量、相对强度、均线多头、量比 |

## 变更

- `scripts/strategy_masters.py` — 大师画像 + 基本面/价格打分
- `scripts/fetch_data.py` — 输出 `masterRecommendations`
- 荐股 Tab — 「战术 v1.3 / 投资大师」子 Tab 切换
- `generate_report.py` — 研报第四章「投资大师风格荐股」
- `.github/API_KEYS_SETUP.md` 无变更（仍用 Yahoo 免费基本面）

## 使用

合并后打开 **荐股 → 投资大师**，每位大师展示 2 只匹配度最高的标的，含 PE/ROE/PEG 等指标与风格化买入/持有/风控建议。

> 规则化模拟，非真实人物操作建议；与战术 v1.3、XRPS 战役仓相互独立。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62fa50dd-4422-4777-aa97-3de214aa93a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62fa50dd-4422-4777-aa97-3de214aa93a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

