### PR TITLE
feat: 新增 Serenity 白毛股神卡脖子荐股策略

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1705,6 +1705,37 @@ a:hover {
   color: var(--text-muted);
 }
 
+.master-card__source-note {
+  margin: 10px 0 0;
+  padding: 8px 10px;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: #fcd34d;
+  background: rgba(251, 191, 36, 0.08);
+  border: 1px solid rgba(251, 191, 36, 0.2);
+}
+
+.master-card--serenity {
+  border-color: rgba(167, 139, 250, 0.45);
+  background:
+    linear-gradient(135deg, rgba(139, 92, 246, 0.08), transparent 55%),
+    rgba(15, 23, 42, 0.45);
+}
+
+.master-card--serenity .master-card__style {
+  color: #c4b5fd;
+}
+
+.master-card__en a {
+  color: #93c5fd;
+  text-decoration: none;
+}
+
+.master-card__en a:hover {
+  text-decoration: underline;
+}
+
 .master-principles {
   display: flex;
   flex-wrap: wrap;

--- a/data/market.json
+++ b/data/market.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-06-27T05:39:26+00:00",
+  "updatedAt": "2026-06-27T05:48:30+00:00",
   "summary": {
     "tracked": 6,
     "up": 0,
@@ -46,6 +46,8 @@
     "000858.SZ": 73.17,
     "688981.SS": 148.76,
     "600036.SS": 36.0,
+    "300308.SZ": 1253.89,
+    "688017.SS": 369.46,
     "0700.HK": 411.8,
     "9988.HK": 89.5,
     "3690.HK": 64.25,
@@ -67,6 +69,8 @@
     "000858.SZ": -12.78,
     "688981.SS": 1.74,
     "600036.SS": -2.7,
+    "300308.SZ": 12.82,
+    "688017.SS": 15.1,
     "0700.HK": -5.2,
     "9988.HK": -27.92,
     "3690.HK": -17.31,
@@ -764,6 +768,36 @@
         "distToTargetPct": 51.9
       },
       {
+        "symbol": "300308.SZ",
+        "name": "中际旭创",
+        "market": "A股",
+        "score": 67.0,
+        "signal": "hold",
+        "signalLabel": "暂不参与",
+        "price": 1253.89,
+        "rsi": 56.4,
+        "relativeStrength": 15.67,
+        "regimeOk": false,
+        "breakout": false,
+        "distToStopPct": 14.5,
+        "distToTargetPct": 52.3
+      },
+      {
+        "symbol": "688017.SS",
+        "name": "绿的谐波",
+        "market": "A股",
+        "score": 67.0,
+        "signal": "hold",
+        "signalLabel": "暂不参与",
+        "price": 369.46,
+        "rsi": 53.6,
+        "relativeStrength": 17.95,
+        "regimeOk": false,
+        "breakout": false,
+        "distToStopPct": 24.3,
+        "distToTargetPct": 87.3
+      },
+      {
         "symbol": "AAPL",
         "name": "苹果",
         "market": "美股",
@@ -1021,9 +1055,9 @@
     ]
   },
   "masterRecommendations": {
-    "version": "v1.0.0",
-    "strategy": "v1.0.0 投资大师风格荐股：基于 Yahoo 基本面与价格特征，模拟 6 位大师选股逻辑；每位大师推荐 2 只，与战术 v1.3 相互独立。",
-    "disclaimer": "大师风格荐股为规则化模拟，非真实人物操作建议；基本面数据可能有延迟或缺失，仅供研究，不构成投资建议。",
+    "version": "v1.1.0",
+    "strategy": "v1.1.0 投资大师风格荐股：基于 Yahoo 基本面与价格特征，模拟 7 位大师选股逻辑；每位大师推荐 2 只，与战术 v1.3 相互独立。",
+    "disclaimer": "大师风格荐股为规则化模拟，非真实人物操作建议；Serenity 相关内容为对其公开框架的量化近似，勿当作 X 账号买卖信号；基本面数据可能有延迟或缺失，仅供研究，不构成投资建议。",
     "masters": [
       {
         "id": "buffett",
@@ -1466,6 +1500,40 @@
         "holdingHorizon": "数周–数月",
         "picks": [
           {
+            "symbol": "300308.SZ",
+            "name": "中际旭创",
+            "market": "A股",
+            "sector": "光模块",
+            "currency": "CNY",
+            "price": 1253.89,
+            "matchScore": 89.0,
+            "signal": "buy",
+            "signalLabel": "符合风格 · 建议关注",
+            "reasons": [
+              "近一月 +12.82% — 趋势强劲，反身性正反馈",
+              "相对强度 +14.44% — 跑赢大盘，宏观共振",
+              "均线多头排列 — 趋势交易确认",
+              "高 Beta 放大趋势 — 索罗斯式进攻配置"
+            ],
+            "plan": {
+              "entry": "趋势确认后于 1253.89 附近顺势建仓；宏观与相对强度共振时加仓。",
+              "holding": "短中期趋势交易（数周–数月）；趋势破坏即减仓。",
+              "risk": "跌破关键均线或相对强度转负时严格止损；反身性逆转要快。",
+              "position": "单大师风格内建议 1–2 只核心标的；与战术策略、XRPS 战役仓独立配置。"
+            },
+            "metrics": {
+              "pe": 93.43,
+              "pb": 39.15,
+              "roe": 53.93,
+              "peg": 36.08,
+              "earningsGrowth": 2.59,
+              "profitMargins": 29.28,
+              "monthChangePct": 12.82,
+              "relativeStrength": 14.44,
+              "rangePosition": 0.87
+            }
+          },
+          {
             "symbol": "AMD",
             "name": "AMD",
             "market": "美股",
@@ -1498,39 +1566,102 @@
               "relativeStrength": 7.46,
               "rangePosition": 0.9
             }
-          },
+          }
+        ]
+      },
+      {
+        "id": "serenity",
+        "name": "白毛股神 Serenity",
+        "nameEn": "Serenity (@aleabitoreddit)",
+        "style": "卡脖子 · 瓶颈猎手",
+        "philosophy": "Own the bottleneck, not the brand — 不买 AI/机器人终端龙头，寻找供应链中绕不过、短期内无法替代的上游稀缺环节（紫苏叶理论）。",
+        "principles": [
+          "瓶颈猎手",
+          "终端需求向上游追溯",
+          "小盘+高壁垒+低覆盖",
+          "机构定价前布局",
+          "证伪点止损"
+        ],
+        "holdingHorizon": "6–18 个月",
+        "picks": [
           {
-            "symbol": "688981.SS",
-            "name": "中芯国际",
+            "symbol": "688017.SS",
+            "name": "绿的谐波",
             "market": "A股",
-            "sector": "半导体",
+            "sector": "精密减速器",
             "currency": "CNY",
-            "price": 148.76,
-            "matchScore": 63.0,
-            "signal": "watch",
-            "signalLabel": "部分符合 · 观察等待",
+            "price": 369.46,
+            "matchScore": 100.0,
+            "signal": "buy",
+            "signalLabel": "符合风格 · 建议关注",
             "reasons": [
-              "均线多头排列 — 趋势交易确认"
+              "精密减速器 — AI/机器人供应链瓶颈相关环节",
+              "紫苏叶环节 · 精密减速器 — 人形机器人卡脖子环节",
+              "中市值 — 仍处价格发现窗口",
+              "盈利增速 56.8% — 瓶颈环节需求释放",
+              "近一月 +15.1% — 重估进行中但未必过热"
             ],
             "plan": {
-              "entry": "趋势确认后于 148.76 附近顺势建仓；宏观与相对强度共振时加仓。",
-              "holding": "短中期趋势交易（数周–数月）；趋势破坏即减仓。",
-              "risk": "跌破关键均线或相对强度转负时严格止损；反身性逆转要快。",
+              "entry": "在 369.46 CNY 附近建立 conviction 仓位；从终端需求（算力/光互连/机器人）向上游追溯，独立验证瓶颈是否仍不可替代。",
+              "holding": "6–18 个月；等待供应链重估、扩产瓶颈确认或并购催化，接受小盘科技股的较大波动。",
+              "risk": "证伪点：技术路线变更、客户找到替代供应商、瓶颈环节扩产后稀缺性消失；不因 X/社交热度末段追高。",
               "position": "单大师风格内建议 1–2 只核心标的；与战术策略、XRPS 战役仓独立配置。"
             },
             "metrics": {
-              "pe": 243.87,
-              "pb": 8.49,
-              "roe": 2.64,
-              "peg": null,
-              "earningsGrowth": 0.0,
-              "profitMargins": 7.25,
-              "monthChangePct": 1.74,
-              "relativeStrength": 3.36,
-              "rangePosition": 0.86
+              "pe": 499.27,
+              "pb": 18.98,
+              "roe": 3.92,
+              "peg": 8.79,
+              "earningsGrowth": 56.8,
+              "profitMargins": 22.31,
+              "monthChangePct": 15.1,
+              "relativeStrength": 16.72,
+              "rangePosition": 0.76,
+              "marketCapB": 67.7,
+              "bottleneckLayer": "精密减速器"
+            }
+          },
+          {
+            "symbol": "AMD",
+            "name": "AMD",
+            "market": "美股",
+            "sector": "半导体",
+            "currency": "USD",
+            "price": 521.58,
+            "matchScore": 84.0,
+            "signal": "buy",
+            "signalLabel": "符合风格 · 建议关注",
+            "reasons": [
+              "半导体 — AI/机器人供应链瓶颈相关环节",
+              "紫苏叶环节 · GPU/CPU — 算力供应链关键环节",
+              "大盘蓝筹 — 非典型卡脖子小盘标的",
+              "盈利增速 91.2% — 瓶颈环节需求释放",
+              "接近日内/年内高位 — 警惕情绪末段追价"
+            ],
+            "plan": {
+              "entry": "在 521.58 USD 附近建立 conviction 仓位；从终端需求（算力/光互连/机器人）向上游追溯，独立验证瓶颈是否仍不可替代。",
+              "holding": "6–18 个月；等待供应链重估、扩产瓶颈确认或并购催化，接受小盘科技股的较大波动。",
+              "risk": "证伪点：技术路线变更、客户找到替代供应商、瓶颈环节扩产后稀缺性消失；不因 X/社交热度末段追高。",
+              "position": "单大师风格内建议 1–2 只核心标的；与战术策略、XRPS 战役仓独立配置。"
+            },
+            "metrics": {
+              "pe": 172.14,
+              "pb": 13.19,
+              "roe": 8.06,
+              "peg": 1.89,
+              "earningsGrowth": 91.2,
+              "profitMargins": 13.37,
+              "monthChangePct": 5.25,
+              "relativeStrength": 7.46,
+              "rangePosition": 0.9,
+              "marketCapB": 850.5,
+              "bottleneckLayer": "GPU/CPU"
             }
           }
-        ]
+        ],
+        "xHandle": "@aleabitoreddit",
+        "platform": "X",
+        "sourceNote": "规则化模拟其公开的「卡脖子/紫苏叶」框架，非本人操作建议"
       }
     ]
   }

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/jsmind@0.8.7/es6/jsmind.js" defer></script>
   <script src="js/ai-mindmap.js" defer></script>
-  <script src="js/app.js?v=23" defer></script>
+  <script src="js/app.js?v=24" defer></script>
 </head>
 <body>
   <div class="app">

--- a/js/app.js
+++ b/js/app.js
@@ -854,6 +854,8 @@ function formatMasterMetric(key, val) {
   if (key === "roe" || key === "profitMargins" || key === "earningsGrowth") return `${formatNumber(val, 1)}%`;
   if (key === "monthChangePct" || key === "relativeStrength") return formatPct(val);
   if (key === "rangePosition") return `${Math.round(val * 100)}%`;
+  if (key === "marketCapB") return `${formatNumber(val, 1)}B`;
+  if (key === "bottleneckLayer") return String(val);
   return String(val);
 }
 
@@ -869,6 +871,8 @@ function renderMasterPickCard(pick) {
     monthChangePct: "近一月",
     relativeStrength: "相对强度",
     rangePosition: "52周区间",
+    marketCapB: "市值",
+    bottleneckLayer: "瓶颈环节",
   };
   const metricHtml = Object.entries(metricLabels)
     .map(([key, label]) => {
@@ -926,14 +930,15 @@ function renderMasterRecommendations(data) {
         ? master.picks.map((p) => renderMasterPickCard(p)).join("")
         : '<p class="empty master-empty">当前候选池暂无符合该风格的标的</p>';
       return `
-        <article class="master-card" id="master-${master.id}">
+        <article class="master-card${master.id === "serenity" ? " master-card--serenity" : ""}" id="master-${master.id}">
           <header class="master-card__head">
             <div>
               <p class="master-card__style">${master.style}</p>
               <h3>${master.name}</h3>
-              <p class="master-card__en">${master.nameEn || ""} · 持有 ${master.holdingHorizon || "—"}</p>
+              <p class="master-card__en">${master.nameEn || ""} · 持有 ${master.holdingHorizon || "—"}${master.xHandle ? ` · <a href="https://x.com/${master.xHandle.replace("@", "")}" target="_blank" rel="noopener noreferrer">${master.xHandle}</a>` : ""}</p>
             </div>
           </header>
+          ${master.sourceNote ? `<p class="master-card__source-note">${master.sourceNote}</p>` : ""}
           <p class="master-card__philosophy">${master.philosophy || ""}</p>
           <ul class="master-principles">${(master.principles || []).map((p) => `<li>${p}</li>`).join("")}</ul>
           <div class="master-picks">${picksHtml}</div>

--- a/scripts/fetch_data.py
+++ b/scripts/fetch_data.py
@@ -42,6 +42,8 @@ CANDIDATES = {
     "000858.SZ": {"name": "五粮液", "sector": "白酒", "currency": "CNY", "market": "A股"},
     "688981.SS": {"name": "中芯国际", "sector": "半导体", "currency": "CNY", "market": "A股"},
     "600036.SS": {"name": "招商银行", "sector": "银行", "currency": "CNY", "market": "A股"},
+    "300308.SZ": {"name": "中际旭创", "sector": "光模块", "currency": "CNY", "market": "A股"},
+    "688017.SS": {"name": "绿的谐波", "sector": "精密减速器", "currency": "CNY", "market": "A股"},
     # 港股
     "0700.HK": {"name": "腾讯控股", "sector": "互联网", "currency": "HKD", "market": "港股"},
     "9988.HK": {"name": "阿里巴巴", "sector": "电商云计算", "currency": "HKD", "market": "港股"},

--- a/scripts/strategy_masters.py
+++ b/scripts/strategy_masters.py
@@ -9,7 +9,7 @@ import yfinance as yf
 
 from strategy_scoring import MARKET_BENCHMARKS, pct_change, sma
 
-MASTER_VERSION = "v1.0.0"
+MASTER_VERSION = "v1.1.0"
 PICKS_PER_MASTER = 2
 MIN_MATCH_SCORE = 48
 
@@ -80,7 +80,53 @@ MASTER_PROFILES: tuple[MasterProfile, ...] = (
         principles=("趋势确认", "相对强度", "宏观共振", "快速止损", "顺势而为"),
         holding="数周–数月",
     ),
+    MasterProfile(
+        id="serenity",
+        name="白毛股神 Serenity",
+        name_en="Serenity (@aleabitoreddit)",
+        style="卡脖子 · 瓶颈猎手",
+        philosophy=(
+            "Own the bottleneck, not the brand — 不买 AI/机器人终端龙头，"
+            "寻找供应链中绕不过、短期内无法替代的上游稀缺环节（紫苏叶理论）。"
+        ),
+        principles=(
+            "瓶颈猎手",
+            "终端需求向上游追溯",
+            "小盘+高壁垒+低覆盖",
+            "机构定价前布局",
+            "证伪点止损",
+        ),
+        holding="6–18 个月",
+    ),
 )
+
+
+# Serenity 产业链瓶颈标签（候选池内），用于加分与展示
+SERENITY_BOTTLENECK_TAGS: dict[str, tuple[str, str]] = {
+    "688981.SS": ("晶圆制造", "AI 算力上游产能瓶颈"),
+    "688017.SS": ("精密减速器", "人形机器人卡脖子环节"),
+    "300308.SZ": ("光模块", "CPO/光互连供应链瓶颈"),
+    "AMD": ("GPU/CPU", "算力供应链关键环节"),
+    "NVDA": ("AI 芯片", "终端龙头 — 非瓶颈主战场"),
+    "300750.SZ": ("动力电池", "数据中心备电/储能环节"),
+    "1810.HK": ("智能硬件", "机器人/IoT 终端生态"),
+    "9992.HK": ("潮玩零售", "非核心瓶颈 — 降权"),
+}
+
+SERENITY_SECTOR_SCORE: dict[str, float] = {
+    "半导体": 22,
+    "光模块": 24,
+    "精密减速器": 24,
+    "新能源": 10,
+    "消费电子": 12,
+    "软件云计算": 6,
+    "电商云计算": 4,
+    "互联网": 2,
+    "白酒": -22,
+    "保险": -20,
+    "银行": -18,
+    "潮玩零售": -12,
+}
 
 
 def _norm_ratio(val: float | None, as_pct: bool = True) -> float | None:
@@ -472,6 +518,91 @@ def _score_soros(ctx: dict) -> tuple[float, list[str]]:
     return _clamp_score(score), reasons[:4]
 
 
+def _score_serenity(ctx: dict) -> tuple[float, list[str]]:
+    """X @aleabitoreddit — 卡脖子投资法 / Bottleneck Hunter。"""
+    score = 38.0
+    reasons: list[str] = []
+    symbol = ctx.get("symbol", "")
+
+    tag = SERENITY_BOTTLENECK_TAGS.get(symbol)
+    sector = ctx.get("sector") or (tag[0] if tag else "")
+    sector_bonus = SERENITY_SECTOR_SCORE.get(sector, 0)
+    if sector_bonus:
+        score += sector_bonus
+        if sector_bonus > 0:
+            reasons.append(f"{sector} — AI/机器人供应链瓶颈相关环节")
+        else:
+            reasons.append(f"{sector} — 非 Serenity 核心瓶颈赛道")
+
+    if tag:
+        layer, note = tag
+        if "非瓶颈" in note or "降权" in note or "终端龙头" in note:
+            score -= 12
+            reasons.append(f"{layer}：{note}")
+        else:
+            score += 14
+            reasons.append(f"紫苏叶环节 · {layer} — {note}")
+
+    mcap = ctx.get("marketCap")
+    if mcap is not None:
+        if mcap < 30e9:
+            score += 16
+            reasons.append("小市值 — 机构覆盖不足、重估弹性大")
+        elif mcap < 100e9:
+            score += 10
+            reasons.append("中市值 — 仍处价格发现窗口")
+        elif mcap < 300e9:
+            score += 2
+        elif mcap > 1e12:
+            score -= 22
+            reasons.append("超大盘龙头 — 「买瓶颈不买品牌」框架下降权")
+        elif mcap > 400e9:
+            score -= 14
+            reasons.append("大盘蓝筹 — 非典型卡脖子小盘标的")
+
+    earn_g = ctx.get("earningsGrowth")
+    rev_g = ctx.get("revenueGrowth")
+    if earn_g is not None and earn_g >= 15:
+        score += 10
+        reasons.append(f"盈利增速 {earn_g}% — 瓶颈环节需求释放")
+    elif earn_g is not None and earn_g >= 5:
+        score += 4
+    if rev_g is not None and rev_g >= 10:
+        score += 6
+
+    rp = ctx.get("rangePosition")
+    if rp is not None and rp < 0.45:
+        score += 10
+        reasons.append("52 周区间偏低 — 或在机构大规模覆盖前")
+    elif rp is not None and rp > 0.85:
+        score -= 8
+        reasons.append("接近日内/年内高位 — 警惕情绪末段追价")
+
+    month = ctx.get("monthChangePct")
+    if month is not None:
+        if 0 < month <= 18:
+            score += 6
+            reasons.append(f"近一月 +{month}% — 重估进行中但未必过热")
+        elif month > 35:
+            score -= 10
+            reasons.append("短期涨幅过大 — 社交情绪驱动后慎追")
+
+    rs = ctx.get("relativeStrength")
+    if rs is not None and rs >= 3:
+        score += 6
+
+    beta = ctx.get("beta")
+    if beta is not None and beta >= 1.15:
+        score += 4
+
+    margins = ctx.get("profitMargins")
+    if margins is not None and margins >= 20:
+        score += 5
+        reasons.append(f"净利率 {margins}% — 环节稀缺性/定价权")
+
+    return _clamp_score(score), reasons[:5]
+
+
 SCORERS: dict[str, Callable[[dict], tuple[float, list[str]]]] = {
     "buffett": _score_buffett,
     "graham": _score_graham,
@@ -479,6 +610,7 @@ SCORERS: dict[str, Callable[[dict], tuple[float, list[str]]]] = {
     "munger": _score_munger,
     "templeton": _score_templeton,
     "soros": _score_soros,
+    "serenity": _score_serenity,
 }
 
 
@@ -513,6 +645,19 @@ def _build_plan(profile: MasterProfile, ctx: dict, score: float) -> dict:
         entry = f"市场极度悲观、价格 {price} 处于低位区间时逆向买入；需确认基本面未实质性恶化。"
         holding = f"等待情绪修复（{profile.holding}）；耐心是关键。"
         risk = "若逆向逻辑被证伪（基本面崩塌），果断止损。"
+    elif profile.id == "serenity":
+        entry = (
+            f"在 {price} {currency} 附近建立 conviction 仓位；"
+            "从终端需求（算力/光互连/机器人）向上游追溯，独立验证瓶颈是否仍不可替代。"
+        )
+        holding = (
+            f"{profile.holding}；等待供应链重估、扩产瓶颈确认或并购催化，"
+            "接受小盘科技股的较大波动。"
+        )
+        risk = (
+            "证伪点：技术路线变更、客户找到替代供应商、瓶颈环节扩产后稀缺性消失；"
+            "不因 X/社交热度末段追高。"
+        )
     else:
         entry = f"趋势确认后于 {price} 附近顺势建仓；宏观与相对强度共振时加仓。"
         holding = f"短中期趋势交易（{profile.holding.strip()}）；趋势破坏即减仓。"
@@ -524,7 +669,26 @@ def _build_plan(profile: MasterProfile, ctx: dict, score: float) -> dict:
 
 def _pick_row(profile: MasterProfile, ctx: dict, score: float, reasons: list[str]) -> dict:
     signal, label = _signal_from_score(score)
-    return {
+    metrics = {
+        "pe": ctx.get("pe"),
+        "pb": ctx.get("pb"),
+        "roe": ctx.get("roe"),
+        "peg": ctx.get("peg"),
+        "earningsGrowth": ctx.get("earningsGrowth"),
+        "profitMargins": ctx.get("profitMargins"),
+        "monthChangePct": ctx.get("monthChangePct"),
+        "relativeStrength": ctx.get("relativeStrength"),
+        "rangePosition": ctx.get("rangePosition"),
+    }
+    if profile.id == "serenity":
+        mcap = ctx.get("marketCap")
+        if mcap is not None:
+            metrics["marketCapB"] = round(mcap / 1e9, 1)
+        tag = SERENITY_BOTTLENECK_TAGS.get(ctx.get("symbol", ""))
+        if tag:
+            metrics["bottleneckLayer"] = tag[0]
+
+    row = {
         "symbol": ctx["symbol"],
         "name": ctx["name"],
         "market": ctx["market"],
@@ -536,18 +700,19 @@ def _pick_row(profile: MasterProfile, ctx: dict, score: float, reasons: list[str
         "signalLabel": label,
         "reasons": reasons,
         "plan": _build_plan(profile, ctx, score),
-        "metrics": {
-            "pe": ctx.get("pe"),
-            "pb": ctx.get("pb"),
-            "roe": ctx.get("roe"),
-            "peg": ctx.get("peg"),
-            "earningsGrowth": ctx.get("earningsGrowth"),
-            "profitMargins": ctx.get("profitMargins"),
-            "monthChangePct": ctx.get("monthChangePct"),
-            "relativeStrength": ctx.get("relativeStrength"),
-            "rangePosition": ctx.get("rangePosition"),
-        },
+        "metrics": metrics,
     }
+    return row
+
+
+def _master_extra(profile: MasterProfile) -> dict:
+    if profile.id == "serenity":
+        return {
+            "xHandle": "@aleabitoreddit",
+            "platform": "X",
+            "sourceNote": "规则化模拟其公开的「卡脖子/紫苏叶」框架，非本人操作建议",
+        }
+    return {}
 
 
 def build_master_recommendations(candidates: dict) -> dict:
@@ -579,6 +744,7 @@ def build_master_recommendations(candidates: dict) -> dict:
                 "principles": list(profile.principles),
                 "holdingHorizon": profile.holding,
                 "picks": picks,
+                **_master_extra(profile),
             }
         )
 
@@ -591,6 +757,7 @@ def build_master_recommendations(candidates: dict) -> dict:
         ),
         "disclaimer": (
             "大师风格荐股为规则化模拟，非真实人物操作建议；"
+            "Serenity 相关内容为对其公开框架的量化近似，勿当作 X 账号买卖信号；"
             "基本面数据可能有延迟或缺失，仅供研究，不构成投资建议。"
         ),
         "masters": masters_out,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

在投资大师荐股模块中新增 **X @aleabitoreddit（白毛股神 Serenity）** 的「卡脖子 / 瓶颈猎手」策略。

## Serenity 框架（规则化模拟）

| 要素 | 说明 |
|------|------|
| 核心 | Own the bottleneck, not the brand — 紫苏叶理论 |
| 选股 | 半导体、光模块、减速器等上游稀缺环节 |
| 偏好 | 中小市值、高壁垒、机构覆盖不足、52 周偏低区间 |
| 降权 | 超大盘终端龙头（NVDA、茅台等「金枪鱼」） |
| 风控 | 技术路线变更 / 替代供应商 / 扩产消除稀缺性 = 证伪点 |

## 变更

- `strategy_masters.py` v1.1.0 — `_score_serenity` + 瓶颈标签
- 候选池 +2：`300308.SZ` 中际旭创、`688017.SS` 绿的谐波
- 前端 Serenity 卡片紫色高亮、链至 X 账号、展示「瓶颈环节 / 市值」指标

> 规则化模拟其**公开框架**，非 Serenity 本人操作建议；勿当作 X 推文买卖信号。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62fa50dd-4422-4777-aa97-3de214aa93a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62fa50dd-4422-4777-aa97-3de214aa93a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

