### PR TITLE
feat: 大师策略每次更新自动学习与权重升级

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1705,6 +1705,17 @@ a:hover {
   color: var(--text-muted);
 }
 
+.master-learning {
+  margin: 10px 0 0;
+  padding: 8px 10px;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  line-height: 1.55;
+  color: #a5b4fc;
+  background: rgba(99, 102, 241, 0.1);
+  border: 1px solid rgba(99, 102, 241, 0.2);
+}
+
 .master-card__source-note {
   margin: 10px 0 0;
   padding: 8px 10px;

--- a/data/market.json
+++ b/data/market.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-06-27T05:48:30+00:00",
+  "updatedAt": "2026-06-27T06:07:29+00:00",
   "summary": {
     "tracked": 6,
     "up": 0,
@@ -506,6 +506,14 @@
   ],
   "news": [
     {
+      "title": "1 Brand New Big Green Flag for XRP (Ripple) in 2026 and Beyond",
+      "link": "https://finance.yahoo.com/markets/crypto/articles/1-brand-big-green-flag-055000387.html",
+      "publisher": "Motley Fool",
+      "related": "NVDA",
+      "publishedAt": "2026-06-27T05:50:00+00:00",
+      "summary": "Ripple can now market its financial services to a major region of the world."
+    },
+    {
       "title": "2 Reasons Not to Invest in SpaceX -- and What to Buy Instead",
       "link": "https://finance.yahoo.com/markets/stocks/articles/2-reasons-not-invest-spacex-052000915.html",
       "publisher": "Motley Fool",
@@ -560,14 +568,6 @@
       "related": "NVDA",
       "publishedAt": "2026-06-27T03:02:00+00:00",
       "summary": "When a chief executive keeps buying his own falling stock, is that a signal worth following?"
-    },
-    {
-      "title": "Can Meta's New $300 Glasses Turn Around the Stock?",
-      "link": "https://finance.yahoo.com/markets/stocks/articles/metas-300-glasses-turn-around-025000108.html",
-      "publisher": "Motley Fool",
-      "related": "NVDA",
-      "publishedAt": "2026-06-27T02:50:00+00:00",
-      "summary": "Meta just rolled out its cheapest pair of smart glasses yet. Will it make a difference?"
     },
     {
       "title": "Enphase Just Found A New Story To Tell",
@@ -668,9 +668,41 @@
   ],
   "recommendations": {
     "strategy": "v1.3.0 强趋势+突破过滤（各市场 1 只）：Regime 过滤 + 仅突破买入；≥72 突破分、≥65 观察。24h 粘性换仓、止损 ATR、盈亏比 1:3.0。",
-    "marketScan": "A股最高 中芯国际(70.1分) · 港股最高 泡泡玛特(25.3分) · 美股最高 AMD(76.3分)",
+    "marketScan": "A股最高 中芯国际(83.1分) · 港股最高 泡泡玛特(25.3分) · 美股最高 AMD(76.3分)",
     "disclaimer": "战术实验策略，仅供研究；非 XRPS 战役持仓。请分散配置、严格执行止损。",
     "picks": [
+      {
+        "symbol": "688981.SS",
+        "name": "中芯国际",
+        "market": "A股",
+        "sector": "半导体",
+        "currency": "CNY",
+        "price": 148.76,
+        "score": 83.1,
+        "signal": "watch",
+        "signalLabel": "趋势达标待突破",
+        "rsi": 60.0,
+        "monthChangePct": 1.74,
+        "relativeStrength": 2.52,
+        "reasons": [
+          "价格站上 20 日均线",
+          "价格站上 60 日均线",
+          "均线多头排列"
+        ],
+        "plan": {
+          "entry": "现价 148.76 轻仓试探；回踩 20 日均线 135.42 或 132.71 附近分批加仓",
+          "stopLoss": "跌破 127.33（约 -14.4%，2.5 倍 ATR）坚决止损",
+          "target": "第一目标 225.92（盈亏比 1:3.0），可分批止盈",
+          "position": "A股标的建议仓位 ≤ 总资金 13.9%（单笔风险 2.0%）；三市场分散配置"
+        },
+        "stopLossPrice": 127.33,
+        "targetPrice": 225.92,
+        "distToStopPct": 14.4,
+        "distToTargetPct": 51.9,
+        "regimeOk": true,
+        "breakout": false,
+        "breakoutLevel": 159.05
+      },
       {
         "symbol": "AMD",
         "name": "AMD",
@@ -683,7 +715,7 @@
         "signalLabel": "建议观察",
         "rsi": 56.1,
         "monthChangePct": 5.25,
-        "relativeStrength": 7.45,
+        "relativeStrength": 6.8,
         "reasons": [
           "价格站上 20 日均线",
           "价格站上 60 日均线",
@@ -702,41 +734,54 @@
         "regimeOk": true,
         "breakout": false,
         "breakoutLevel": 562.99
-      },
+      }
+    ],
+    "candidateScan": [
       {
         "symbol": "688981.SS",
         "name": "中芯国际",
         "market": "A股",
-        "sector": "半导体",
-        "currency": "CNY",
-        "price": 148.76,
-        "score": 70.1,
+        "score": 83.1,
         "signal": "watch",
-        "signalLabel": "弱信号观察",
+        "signalLabel": "趋势达标待突破",
+        "price": 148.76,
         "rsi": 60.0,
-        "monthChangePct": 1.74,
-        "relativeStrength": 4.59,
-        "reasons": [
-          "价格站上 20 日均线",
-          "价格站上 60 日均线",
-          "均线多头排列"
-        ],
-        "plan": {
-          "entry": "现价 148.76 轻仓试探；回踩 20 日均线 135.42 或 132.71 附近分批加仓",
-          "stopLoss": "跌破 127.33（约 -14.4%，2.5 倍 ATR）坚决止损",
-          "target": "第一目标 225.92（盈亏比 1:3.0），可分批止盈",
-          "position": "A股标的建议仓位 ≤ 总资金 13.9%（单笔风险 2.0%）；三市场分散配置"
-        },
-        "stopLossPrice": 127.33,
-        "targetPrice": 225.92,
-        "distToStopPct": 14.4,
-        "distToTargetPct": 51.9,
-        "regimeOk": false,
+        "relativeStrength": 2.52,
+        "regimeOk": true,
         "breakout": false,
-        "breakoutLevel": 159.05
-      }
-    ],
-    "candidateScan": [
+        "distToStopPct": 14.4,
+        "distToTargetPct": 51.9
+      },
+      {
+        "symbol": "300308.SZ",
+        "name": "中际旭创",
+        "market": "A股",
+        "score": 80.0,
+        "signal": "watch",
+        "signalLabel": "趋势达标待突破",
+        "price": 1253.89,
+        "rsi": 56.4,
+        "relativeStrength": 13.6,
+        "regimeOk": true,
+        "breakout": false,
+        "distToStopPct": 14.5,
+        "distToTargetPct": 52.3
+      },
+      {
+        "symbol": "688017.SS",
+        "name": "绿的谐波",
+        "market": "A股",
+        "score": 80.0,
+        "signal": "watch",
+        "signalLabel": "趋势达标待突破",
+        "price": 369.46,
+        "rsi": 53.6,
+        "relativeStrength": 15.88,
+        "regimeOk": true,
+        "breakout": false,
+        "distToStopPct": 24.3,
+        "distToTargetPct": 87.3
+      },
       {
         "symbol": "AMD",
         "name": "AMD",
@@ -746,56 +791,11 @@
         "signalLabel": "建议观察",
         "price": 521.58,
         "rsi": 56.1,
-        "relativeStrength": 7.45,
+        "relativeStrength": 6.8,
         "regimeOk": true,
         "breakout": false,
         "distToStopPct": 17.3,
         "distToTargetPct": 62.3
-      },
-      {
-        "symbol": "688981.SS",
-        "name": "中芯国际",
-        "market": "A股",
-        "score": 70.1,
-        "signal": "hold",
-        "signalLabel": "暂不参与",
-        "price": 148.76,
-        "rsi": 60.0,
-        "relativeStrength": 4.59,
-        "regimeOk": false,
-        "breakout": false,
-        "distToStopPct": 14.4,
-        "distToTargetPct": 51.9
-      },
-      {
-        "symbol": "300308.SZ",
-        "name": "中际旭创",
-        "market": "A股",
-        "score": 67.0,
-        "signal": "hold",
-        "signalLabel": "暂不参与",
-        "price": 1253.89,
-        "rsi": 56.4,
-        "relativeStrength": 15.67,
-        "regimeOk": false,
-        "breakout": false,
-        "distToStopPct": 14.5,
-        "distToTargetPct": 52.3
-      },
-      {
-        "symbol": "688017.SS",
-        "name": "绿的谐波",
-        "market": "A股",
-        "score": 67.0,
-        "signal": "hold",
-        "signalLabel": "暂不参与",
-        "price": 369.46,
-        "rsi": 53.6,
-        "relativeStrength": 17.95,
-        "regimeOk": false,
-        "breakout": false,
-        "distToStopPct": 24.3,
-        "distToTargetPct": 87.3
       },
       {
         "symbol": "AAPL",
@@ -806,7 +806,7 @@
         "signalLabel": "暂不参与",
         "price": 283.78,
         "rsi": 41.3,
-        "relativeStrength": -6.51,
+        "relativeStrength": -7.16,
         "regimeOk": true,
         "breakout": false,
         "distToStopPct": 8.1,
@@ -821,7 +821,7 @@
         "signalLabel": "暂不参与",
         "price": 337.39,
         "rsi": 33.3,
-        "relativeStrength": -10.98,
+        "relativeStrength": -11.63,
         "regimeOk": true,
         "breakout": false,
         "distToStopPct": 9.4,
@@ -843,6 +843,21 @@
         "distToTargetPct": 45.7
       },
       {
+        "symbol": "300750.SZ",
+        "name": "宁德时代",
+        "market": "A股",
+        "score": 16.0,
+        "signal": "hold",
+        "signalLabel": "暂不参与",
+        "price": 381.0,
+        "rsi": 40.5,
+        "relativeStrength": -7.37,
+        "regimeOk": true,
+        "breakout": false,
+        "distToStopPct": 10.5,
+        "distToTargetPct": 37.9
+      },
+      {
         "symbol": "NVDA",
         "name": "英伟达",
         "market": "美股",
@@ -851,26 +866,11 @@
         "signalLabel": "暂不参与",
         "price": 192.53,
         "rsi": 37.6,
-        "relativeStrength": -7.13,
+        "relativeStrength": -7.78,
         "regimeOk": true,
         "breakout": false,
         "distToStopPct": 8.7,
         "distToTargetPct": 31.5
-      },
-      {
-        "symbol": "600036.SS",
-        "name": "招商银行",
-        "market": "A股",
-        "score": 11.0,
-        "signal": "hold",
-        "signalLabel": "暂不参与",
-        "price": 36.0,
-        "rsi": 30.6,
-        "relativeStrength": 0.15,
-        "regimeOk": false,
-        "breakout": false,
-        "distToStopPct": 4.8,
-        "distToTargetPct": 17.4
       },
       {
         "symbol": "0700.HK",
@@ -896,7 +896,7 @@
         "signalLabel": "暂不参与",
         "price": 372.97,
         "rsi": 40.5,
-        "relativeStrength": -7.42,
+        "relativeStrength": -8.07,
         "regimeOk": false,
         "breakout": false,
         "distToStopPct": 8.4,
@@ -911,26 +911,26 @@
         "signalLabel": "暂不参与",
         "price": 232.69,
         "rsi": 39.5,
-        "relativeStrength": -12.21,
+        "relativeStrength": -12.86,
         "regimeOk": false,
         "breakout": false,
         "distToStopPct": 8.9,
         "distToTargetPct": 31.9
       },
       {
-        "symbol": "300750.SZ",
-        "name": "宁德时代",
+        "symbol": "600036.SS",
+        "name": "招商银行",
         "market": "A股",
-        "score": 3.0,
+        "score": 5.0,
         "signal": "hold",
         "signalLabel": "暂不参与",
-        "price": 381.0,
-        "rsi": 40.5,
-        "relativeStrength": -5.3,
+        "price": 36.0,
+        "rsi": 30.6,
+        "relativeStrength": -1.92,
         "regimeOk": false,
         "breakout": false,
-        "distToStopPct": 10.5,
-        "distToTargetPct": 37.9
+        "distToStopPct": 4.8,
+        "distToTargetPct": 17.4
       },
       {
         "symbol": "600519.SS",
@@ -941,7 +941,7 @@
         "signalLabel": "暂不参与",
         "price": 1168.63,
         "rsi": 31.5,
-        "relativeStrength": -5.34,
+        "relativeStrength": -7.41,
         "regimeOk": false,
         "breakout": false,
         "distToStopPct": 5.7,
@@ -956,7 +956,7 @@
         "signalLabel": "暂不参与",
         "price": 47.23,
         "rsi": 32.1,
-        "relativeStrength": -5.51,
+        "relativeStrength": -7.58,
         "regimeOk": false,
         "breakout": false,
         "distToStopPct": 10.2,
@@ -971,7 +971,7 @@
         "signalLabel": "暂不参与",
         "price": 73.17,
         "rsi": 24.2,
-        "relativeStrength": -9.93,
+        "relativeStrength": -12.0,
         "regimeOk": false,
         "breakout": false,
         "distToStopPct": 6.9,
@@ -1046,7 +1046,7 @@
         "signalLabel": "暂不参与",
         "price": 550.25,
         "rsi": 37.5,
-        "relativeStrength": -11.1,
+        "relativeStrength": -11.75,
         "regimeOk": false,
         "breakout": false,
         "distToStopPct": 8.3,
@@ -1055,9 +1055,18 @@
     ]
   },
   "masterRecommendations": {
-    "version": "v1.1.0",
-    "strategy": "v1.1.0 投资大师风格荐股：基于 Yahoo 基本面与价格特征，模拟 7 位大师选股逻辑；每位大师推荐 2 只，与战术 v1.3 相互独立。",
-    "disclaimer": "大师风格荐股为规则化模拟，非真实人物操作建议；Serenity 相关内容为对其公开框架的量化近似，勿当作 X 账号买卖信号；基本面数据可能有延迟或缺失，仅供研究，不构成投资建议。",
+    "version": "v1.2.1",
+    "strategy": "v1.2.1 投资大师风格荐股（在线学习）：每次数据更新根据历史荐股表现与市场环境微调 7 位大师因子权重；当前市场环境 risk_off。",
+    "disclaimer": "大师风格荐股为规则化模拟，非真实人物操作建议；权重学习基于历史快照与公开行情，样本不足时变化极小；Serenity 相关内容为对其公开框架的量化近似，勿当作 X 账号买卖信号；仅供研究，不构成投资建议。",
+    "learning": {
+      "revision": 1,
+      "regime": "risk_off",
+      "updatedAt": "2026-06-27T06:07:29+00:00",
+      "lastUpgrade": "2026-06-27T06:07:29+00:00",
+      "notes": {
+        "_regime": "市场环境(risk_off)：graham×1.06、templeton×1.08、buffett×1.04、soros×0.94"
+      }
+    },
     "masters": [
       {
         "id": "buffett",
@@ -1090,6 +1099,14 @@
               "净利率 30.61% — 业务具备定价权",
               "负债率可控，财务风险较低"
             ],
+            "factors": {
+              "roe": 18.72,
+              "pe": 12.48,
+              "margins": 8.32,
+              "debt": 6.24,
+              "trend": 10.4,
+              "mcap": 4.16
+            },
             "plan": {
               "entry": "围绕 411.8 HKD 分批建仓，优先在回调至年线附近加仓；不追短线热点。",
               "holding": "持有期 3–10 年+；关注 ROE 与护城河是否恶化。",
@@ -1124,6 +1141,14 @@
               "净利率 16.87% — 业务具备定价权",
               "负债率可控，财务风险较低"
             ],
+            "factors": {
+              "roe": 18.72,
+              "pe": 12.48,
+              "margins": 8.32,
+              "debt": 6.24,
+              "trend": 8.32,
+              "mcap": 4.16
+            },
             "plan": {
               "entry": "围绕 381.0 CNY 分批建仓，优先在回调至年线附近加仓；不追短线热点。",
               "holding": "持有期 3–10 年+；关注 ROE 与护城河是否恶化。",
@@ -1142,7 +1167,16 @@
               "rangePosition": 0.6
             }
           }
-        ]
+        ],
+        "learning": {
+          "revision": 1,
+          "regime": "risk_off",
+          "samples": 0,
+          "winRate": null,
+          "avgReturnPct": null,
+          "upgradeNote": null,
+          "lastUpgrade": "2026-06-27T06:07:29+00:00"
+        }
       },
       {
         "id": "graham",
@@ -1175,6 +1209,12 @@
               "价格处于 52 周区间下沿 — 悲观定价带来安全边际",
               "股息率 8.37% — 提供下行保护垫"
             ],
+            "factors": {
+              "pe": 23.32,
+              "pb": 19.08,
+              "range": 12.72,
+              "dividend": 5.3
+            },
             "plan": {
               "entry": "仅在 36.0 附近或更低、且 PE/PB 维持低位时分批买入；拒绝「便宜但坏」的公司。",
               "holding": "持有至估值修复至合理区间（1–3 年）。",
@@ -1209,6 +1249,12 @@
               "价格处于 52 周区间下沿 — 悲观定价带来安全边际",
               "股息率 5.72% — 提供下行保护垫"
             ],
+            "factors": {
+              "pe": 23.32,
+              "pb": 19.08,
+              "range": 12.72,
+              "dividend": 5.3
+            },
             "plan": {
               "entry": "仅在 47.23 附近或更低、且 PE/PB 维持低位时分批买入；拒绝「便宜但坏」的公司。",
               "holding": "持有至估值修复至合理区间（1–3 年）。",
@@ -1227,7 +1273,16 @@
               "rangePosition": 0.0
             }
           }
-        ]
+        ],
+        "learning": {
+          "revision": 1,
+          "regime": "risk_off",
+          "samples": 0,
+          "winRate": null,
+          "avgReturnPct": null,
+          "upgradeNote": null,
+          "lastUpgrade": "2026-06-27T06:07:29+00:00"
+        }
       },
       {
         "id": "lynch",
@@ -1260,6 +1315,12 @@
               "营收增速 52.4% — 业务扩张持续",
               "新能源 — 林奇偏好的可理解成长行业"
             ],
+            "factors": {
+              "peg": 22.0,
+              "earnings": 16.0,
+              "revenue": 6.0,
+              "sector": 4.0
+            },
             "plan": {
               "entry": "确认 PEG 与盈利增速匹配后，于 381.0 附近建仓；季度财报验证成长逻辑。",
               "holding": "成长故事兑现或 PEG > 2 时考虑获利（1–5 年）。",
@@ -1294,6 +1355,12 @@
               "营收增速 16.6% — 业务扩张持续",
               "电商云计算 — 林奇偏好的可理解成长行业"
             ],
+            "factors": {
+              "peg": 22.0,
+              "earnings": 16.0,
+              "revenue": 6.0,
+              "sector": 4.0
+            },
             "plan": {
               "entry": "确认 PEG 与盈利增速匹配后，于 232.69 附近建仓；季度财报验证成长逻辑。",
               "holding": "成长故事兑现或 PEG > 2 时考虑获利（1–5 年）。",
@@ -1312,7 +1379,16 @@
               "rangePosition": 0.44
             }
           }
-        ]
+        ],
+        "learning": {
+          "revision": 1,
+          "regime": "risk_off",
+          "samples": 0,
+          "winRate": null,
+          "avgReturnPct": null,
+          "upgradeNote": null,
+          "lastUpgrade": "2026-06-27T06:07:29+00:00"
+        }
       },
       {
         "id": "munger",
@@ -1345,6 +1421,12 @@
               "低杠杆 — 符合芒格「避免愚蠢」原则",
               "优质公司合理溢价可接受 — 以合理价格买伟大公司"
             ],
+            "factors": {
+              "roe": 20.0,
+              "margins": 14.0,
+              "debt": 8.0,
+              "pe": 8.0
+            },
             "plan": {
               "entry": "以 1168.63 为参考价，在优质复利逻辑未变前提下长期持有；好公司少动。",
               "holding": "5 年+；与伟大企业共同成长。",
@@ -1379,6 +1461,12 @@
               "低杠杆 — 符合芒格「避免愚蠢」原则",
               "优质公司合理溢价可接受 — 以合理价格买伟大公司"
             ],
+            "factors": {
+              "roe": 20.0,
+              "margins": 14.0,
+              "debt": 8.0,
+              "pe": 8.0
+            },
             "plan": {
               "entry": "以 158.5 为参考价，在优质复利逻辑未变前提下长期持有；好公司少动。",
               "holding": "5 年+；与伟大企业共同成长。",
@@ -1397,7 +1485,16 @@
               "rangePosition": 0.09
             }
           }
-        ]
+        ],
+        "learning": {
+          "revision": 1,
+          "regime": "risk_off",
+          "samples": 0,
+          "winRate": null,
+          "avgReturnPct": null,
+          "upgradeNote": null,
+          "lastUpgrade": "2026-06-27T06:07:29+00:00"
+        }
       },
       {
         "id": "templeton",
@@ -1421,7 +1518,7 @@
             "sector": "消费电子",
             "currency": "HKD",
             "price": 21.42,
-            "matchScore": 96.0,
+            "matchScore": 100.0,
             "signal": "buy",
             "signalLabel": "符合风格 · 建议关注",
             "reasons": [
@@ -1430,6 +1527,13 @@
               "价格接近 52 周底部 — 「极度悲观时买入」",
               "PE 11.9 — 悲观中仍有估值支撑"
             ],
+            "factors": {
+              "month": 17.28,
+              "quarter": 10.8,
+              "range": 15.12,
+              "pe": 8.64,
+              "roe": 6.48
+            },
             "plan": {
               "entry": "市场极度悲观、价格 21.42 处于低位区间时逆向买入；需确认基本面未实质性恶化。",
               "holding": "等待情绪修复（2–5 年）；耐心是关键。",
@@ -1455,7 +1559,7 @@
             "sector": "白酒",
             "currency": "CNY",
             "price": 1168.63,
-            "matchScore": 96.0,
+            "matchScore": 100.0,
             "signal": "buy",
             "signalLabel": "符合风格 · 建议关注",
             "reasons": [
@@ -1464,6 +1568,13 @@
               "价格接近 52 周底部 — 「极度悲观时买入」",
               "PE 17.7 — 悲观中仍有估值支撑"
             ],
+            "factors": {
+              "month": 17.28,
+              "quarter": 10.8,
+              "range": 15.12,
+              "pe": 8.64,
+              "roe": 6.48
+            },
             "plan": {
               "entry": "市场极度悲观、价格 1168.63 处于低位区间时逆向买入；需确认基本面未实质性恶化。",
               "holding": "等待情绪修复（2–5 年）；耐心是关键。",
@@ -1482,7 +1593,16 @@
               "rangePosition": 0.0
             }
           }
-        ]
+        ],
+        "learning": {
+          "revision": 1,
+          "regime": "risk_off",
+          "samples": 0,
+          "winRate": null,
+          "avgReturnPct": null,
+          "upgradeNote": null,
+          "lastUpgrade": "2026-06-27T06:07:29+00:00"
+        }
       },
       {
         "id": "soros",
@@ -1506,7 +1626,7 @@
             "sector": "光模块",
             "currency": "CNY",
             "price": 1253.89,
-            "matchScore": 89.0,
+            "matchScore": 86.4,
             "signal": "buy",
             "signalLabel": "符合风格 · 建议关注",
             "reasons": [
@@ -1515,6 +1635,12 @@
               "均线多头排列 — 趋势交易确认",
               "高 Beta 放大趋势 — 索罗斯式进攻配置"
             ],
+            "factors": {
+              "month": 15.04,
+              "rs": 13.16,
+              "trend": 9.4,
+              "beta": 3.76
+            },
             "plan": {
               "entry": "趋势确认后于 1253.89 附近顺势建仓；宏观与相对强度共振时加仓。",
               "holding": "短中期趋势交易（数周–数月）；趋势破坏即减仓。",
@@ -1540,7 +1666,7 @@
             "sector": "半导体",
             "currency": "USD",
             "price": 521.58,
-            "matchScore": 89.0,
+            "matchScore": 86.4,
             "signal": "buy",
             "signalLabel": "符合风格 · 建议关注",
             "reasons": [
@@ -1549,6 +1675,13 @@
               "量比 1.64 — 资金参与度高",
               "高 Beta 放大趋势 — 索罗斯式进攻配置"
             ],
+            "factors": {
+              "month": 9.4,
+              "rs": 13.16,
+              "trend": 9.4,
+              "volume": 5.64,
+              "beta": 3.76
+            },
             "plan": {
               "entry": "趋势确认后于 521.58 附近顺势建仓；宏观与相对强度共振时加仓。",
               "holding": "短中期趋势交易（数周–数月）；趋势破坏即减仓。",
@@ -1567,7 +1700,16 @@
               "rangePosition": 0.9
             }
           }
-        ]
+        ],
+        "learning": {
+          "revision": 1,
+          "regime": "risk_off",
+          "samples": 0,
+          "winRate": null,
+          "avgReturnPct": null,
+          "upgradeNote": null,
+          "lastUpgrade": "2026-06-27T06:07:29+00:00"
+        }
       },
       {
         "id": "serenity",
@@ -1601,6 +1743,13 @@
               "盈利增速 56.8% — 瓶颈环节需求释放",
               "近一月 +15.1% — 重估进行中但未必过热"
             ],
+            "factors": {
+              "sector": 24.0,
+              "tag": 14.0,
+              "mcap": 10.0,
+              "growth": 21.0,
+              "momentum": 12.0
+            },
             "plan": {
               "entry": "在 369.46 CNY 附近建立 conviction 仓位；从终端需求（算力/光互连/机器人）向上游追溯，独立验证瓶颈是否仍不可替代。",
               "holding": "6–18 个月；等待供应链重估、扩产瓶颈确认或并购催化，接受小盘科技股的较大波动。",
@@ -1638,6 +1787,14 @@
               "盈利增速 91.2% — 瓶颈环节需求释放",
               "接近日内/年内高位 — 警惕情绪末段追价"
             ],
+            "factors": {
+              "sector": 22.0,
+              "tag": 14.0,
+              "mcap": -14.0,
+              "growth": 16.0,
+              "range": -8.0,
+              "momentum": 16.0
+            },
             "plan": {
               "entry": "在 521.58 USD 附近建立 conviction 仓位；从终端需求（算力/光互连/机器人）向上游追溯，独立验证瓶颈是否仍不可替代。",
               "holding": "6–18 个月；等待供应链重估、扩产瓶颈确认或并购催化，接受小盘科技股的较大波动。",
@@ -1659,6 +1816,15 @@
             }
           }
         ],
+        "learning": {
+          "revision": 1,
+          "regime": "risk_off",
+          "samples": 0,
+          "winRate": null,
+          "avgReturnPct": null,
+          "upgradeNote": null,
+          "lastUpgrade": "2026-06-27T06:07:29+00:00"
+        },
         "xHandle": "@aleabitoreddit",
         "platform": "X",
         "sourceNote": "规则化模拟其公开的「卡脖子/紫苏叶」框架，非本人操作建议"

--- a/data/master_reco_history.json
+++ b/data/master_reco_history.json
@@ -1,0 +1,227 @@
+{
+  "version": 1,
+  "records": [
+    {
+      "id": "2026-06-27T06:07:29+00:00",
+      "recordedAt": "2026-06-27T06:07:29+00:00",
+      "version": "v1.2.1",
+      "masters": [
+        {
+          "id": "buffett",
+          "picks": [
+            {
+              "symbol": "0700.HK",
+              "name": "腾讯控股",
+              "price": 411.8,
+              "matchScore": 100.0,
+              "factors": {
+                "roe": 18.72,
+                "pe": 12.48,
+                "margins": 8.32,
+                "debt": 6.24,
+                "trend": 10.4,
+                "mcap": 4.16
+              }
+            },
+            {
+              "symbol": "300750.SZ",
+              "name": "宁德时代",
+              "price": 381.0,
+              "matchScore": 100.0,
+              "factors": {
+                "roe": 18.72,
+                "pe": 12.48,
+                "margins": 8.32,
+                "debt": 6.24,
+                "trend": 8.32,
+                "mcap": 4.16
+              }
+            }
+          ]
+        },
+        {
+          "id": "graham",
+          "picks": [
+            {
+              "symbol": "600036.SS",
+              "name": "招商银行",
+              "price": 36.0,
+              "matchScore": 100.0,
+              "factors": {
+                "pe": 23.32,
+                "pb": 19.08,
+                "range": 12.72,
+                "dividend": 5.3
+              }
+            },
+            {
+              "symbol": "601318.SS",
+              "name": "中国平安",
+              "price": 47.23,
+              "matchScore": 100.0,
+              "factors": {
+                "pe": 23.32,
+                "pb": 19.08,
+                "range": 12.72,
+                "dividend": 5.3
+              }
+            }
+          ]
+        },
+        {
+          "id": "lynch",
+          "picks": [
+            {
+              "symbol": "300750.SZ",
+              "name": "宁德时代",
+              "price": 381.0,
+              "matchScore": 96.0,
+              "factors": {
+                "peg": 22.0,
+                "earnings": 16.0,
+                "revenue": 6.0,
+                "sector": 4.0
+              }
+            },
+            {
+              "symbol": "AMZN",
+              "name": "亚马逊",
+              "price": 232.69,
+              "matchScore": 96.0,
+              "factors": {
+                "peg": 22.0,
+                "earnings": 16.0,
+                "revenue": 6.0,
+                "sector": 4.0
+              }
+            }
+          ]
+        },
+        {
+          "id": "munger",
+          "picks": [
+            {
+              "symbol": "600519.SS",
+              "name": "贵州茅台",
+              "price": 1168.63,
+              "matchScore": 100.0,
+              "factors": {
+                "roe": 20.0,
+                "margins": 14.0,
+                "debt": 8.0,
+                "pe": 8.0
+              }
+            },
+            {
+              "symbol": "9992.HK",
+              "name": "泡泡玛特",
+              "price": 158.5,
+              "matchScore": 100.0,
+              "factors": {
+                "roe": 20.0,
+                "margins": 14.0,
+                "debt": 8.0,
+                "pe": 8.0
+              }
+            }
+          ]
+        },
+        {
+          "id": "templeton",
+          "picks": [
+            {
+              "symbol": "1810.HK",
+              "name": "小米集团",
+              "price": 21.42,
+              "matchScore": 100.0,
+              "factors": {
+                "month": 17.28,
+                "quarter": 10.8,
+                "range": 15.12,
+                "pe": 8.64,
+                "roe": 6.48
+              }
+            },
+            {
+              "symbol": "600519.SS",
+              "name": "贵州茅台",
+              "price": 1168.63,
+              "matchScore": 100.0,
+              "factors": {
+                "month": 17.28,
+                "quarter": 10.8,
+                "range": 15.12,
+                "pe": 8.64,
+                "roe": 6.48
+              }
+            }
+          ]
+        },
+        {
+          "id": "soros",
+          "picks": [
+            {
+              "symbol": "300308.SZ",
+              "name": "中际旭创",
+              "price": 1253.89,
+              "matchScore": 86.4,
+              "factors": {
+                "month": 15.04,
+                "rs": 13.16,
+                "trend": 9.4,
+                "beta": 3.76
+              }
+            },
+            {
+              "symbol": "AMD",
+              "name": "AMD",
+              "price": 521.58,
+              "matchScore": 86.4,
+              "factors": {
+                "month": 9.4,
+                "rs": 13.16,
+                "trend": 9.4,
+                "volume": 5.64,
+                "beta": 3.76
+              }
+            }
+          ]
+        },
+        {
+          "id": "serenity",
+          "picks": [
+            {
+              "symbol": "688017.SS",
+              "name": "绿的谐波",
+              "price": 369.46,
+              "matchScore": 100.0,
+              "factors": {
+                "sector": 24.0,
+                "tag": 14.0,
+                "mcap": 10.0,
+                "growth": 21.0,
+                "momentum": 12.0
+              }
+            },
+            {
+              "symbol": "AMD",
+              "name": "AMD",
+              "price": 521.58,
+              "matchScore": 84.0,
+              "factors": {
+                "sector": 22.0,
+                "tag": 14.0,
+                "mcap": -14.0,
+                "growth": 16.0,
+                "range": -8.0,
+                "momentum": 16.0
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "updatedAt": "2026-06-27T06:07:29+00:00",
+  "total": 1
+}

--- a/data/master_strategy_state.json
+++ b/data/master_strategy_state.json
@@ -1,0 +1,99 @@
+{
+  "baseVersion": "v1.2",
+  "revision": 1,
+  "updatedAt": "2026-06-27T06:07:29+00:00",
+  "weights": {
+    "buffett": {
+      "roe": 1.04,
+      "pe": 1.04,
+      "margins": 1.04,
+      "debt": 1.04,
+      "trend": 1.04,
+      "mcap": 1.04
+    },
+    "graham": {
+      "pe": 1.06,
+      "pb": 1.06,
+      "range": 1.06,
+      "dividend": 1.06,
+      "debt": 1.06
+    },
+    "lynch": {
+      "peg": 1.0,
+      "earnings": 1.0,
+      "revenue": 1.0,
+      "sector": 1.0
+    },
+    "munger": {
+      "roe": 1.0,
+      "margins": 1.0,
+      "debt": 1.0,
+      "pe": 1.0,
+      "trend": 1.0
+    },
+    "templeton": {
+      "month": 1.08,
+      "quarter": 1.08,
+      "range": 1.08,
+      "pe": 1.08,
+      "roe": 1.08
+    },
+    "soros": {
+      "month": 0.94,
+      "rs": 0.94,
+      "trend": 0.94,
+      "volume": 0.94,
+      "beta": 0.94
+    },
+    "serenity": {
+      "sector": 1.0,
+      "tag": 1.0,
+      "mcap": 1.0,
+      "growth": 1.0,
+      "range": 1.0,
+      "momentum": 1.0
+    }
+  },
+  "performance": {
+    "buffett": {
+      "samples": 0,
+      "winRate": null,
+      "avgReturnPct": null
+    },
+    "graham": {
+      "samples": 0,
+      "winRate": null,
+      "avgReturnPct": null
+    },
+    "lynch": {
+      "samples": 0,
+      "winRate": null,
+      "avgReturnPct": null
+    },
+    "munger": {
+      "samples": 0,
+      "winRate": null,
+      "avgReturnPct": null
+    },
+    "templeton": {
+      "samples": 0,
+      "winRate": null,
+      "avgReturnPct": null
+    },
+    "soros": {
+      "samples": 0,
+      "winRate": null,
+      "avgReturnPct": null
+    },
+    "serenity": {
+      "samples": 0,
+      "winRate": null,
+      "avgReturnPct": null
+    }
+  },
+  "lastUpgrade": "2026-06-27T06:07:29+00:00",
+  "upgradeNotes": {
+    "_regime": "市场环境(risk_off)：graham×1.06、templeton×1.08、buffett×1.04、soros×0.94"
+  },
+  "regime": "risk_off"
+}

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/jsmind@0.8.7/es6/jsmind.js" defer></script>
   <script src="js/ai-mindmap.js" defer></script>
-  <script src="js/app.js?v=25" defer></script>
+  <script src="js/app.js?v=26" defer></script>
 </head>
 <body>
   <div class="app">

--- a/js/app.js
+++ b/js/app.js
@@ -958,11 +958,22 @@ function renderMasterRecommendations(data) {
   if (strategyEl && data.strategy) strategyEl.textContent = data.strategy;
   if (disclaimerEl) disclaimerEl.textContent = data.disclaimer || "";
 
+  const learning = data.learning || {};
+  const learningHint = learning.regime
+    ? `策略版本 ${data.version || "—"} · 市场环境 ${learning.regime}${learning.revision != null ? ` · 修订 r${learning.revision}` : ""}`
+    : "";
+
   grid.innerHTML = data.masters
     .map((master) => {
       const picksHtml = master.picks?.length
         ? master.picks.map((p) => renderMasterPickCard(p)).join("")
         : '<p class="empty master-empty">当前候选池暂无符合该风格的标的</p>';
+      const learn = master.learning || {};
+      const learnHtml = learn.samples
+        ? `<p class="master-learning">学习反馈 · 样本 ${learn.samples} · 胜率 ${learn.winRate ?? "--"}% · 均收益 ${formatPct(learn.avgReturnPct)}${learn.upgradeNote ? ` · ${learn.upgradeNote}` : ""}</p>`
+        : learn.upgradeNote
+          ? `<p class="master-learning">${learn.upgradeNote}</p>`
+          : "";
       return `
         <article class="master-card${master.id === "serenity" ? " master-card--serenity" : ""}" id="master-${master.id}">
           <header class="master-card__head">
@@ -974,12 +985,17 @@ function renderMasterRecommendations(data) {
           </header>
           ${master.sourceNote ? `<p class="master-card__source-note">${master.sourceNote}</p>` : ""}
           <p class="master-card__philosophy">${master.philosophy || ""}</p>
+          ${learnHtml}
           <ul class="master-principles">${(master.principles || []).map((p) => `<li>${p}</li>`).join("")}</ul>
           <div class="master-picks">${picksHtml}</div>
         </article>
       `;
     })
     .join("");
+
+  if (learningHint && strategyEl) {
+    strategyEl.textContent = `${data.strategy || ""} ${learningHint ? `（${learningHint}）` : ""}`.trim();
+  }
 }
 
 function switchRecoMode(mode, options = {}) {

--- a/scripts/fetch_data.py
+++ b/scripts/fetch_data.py
@@ -552,12 +552,27 @@ def build_summary(indices: list[dict]) -> dict:
 def main() -> None:
     DATA_DIR.mkdir(parents=True, exist_ok=True)
 
+    now = datetime.now(timezone.utc).astimezone()
     indices = [fetch_quote(symbol, meta) for symbol, meta in INDICES.items()]
     stocks = [fetch_quote(symbol, meta) for symbol, meta in STOCKS.items()]
     news = fetch_news()
-    now = datetime.now(timezone.utc).astimezone()
     recommendations, quote_map, change_map = build_recommendations(now)
-    master_recommendations = build_master_recommendations(CANDIDATES)
+
+    macro = None
+    macro_file = DATA_DIR / "macro.json"
+    if macro_file.exists():
+        try:
+            macro = json.loads(macro_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            macro = None
+
+    market_ctx = {
+        "summary": build_summary(indices),
+        "marketRadar": build_market_radar(indices),
+    }
+    master_recommendations = build_master_recommendations(
+        CANDIDATES, quote_map, market_ctx, macro, now
+    )
     for item in stocks:
         if item.get("symbol") and item.get("changePct") is not None:
             change_map[item["symbol"]] = item["changePct"]

--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -299,9 +299,15 @@ def master_reco_section(market: dict | None) -> str:
     if not masters:
         return "大师风格荐股数据暂缺。"
 
+    learning = data.get("learning") or {}
     parts = [
-        f"基于候选池基本面与价格特征，模拟 **{len(masters)}** 位投资大师选股框架（{data.get('version', 'v1.0')}）。"
+        f"基于候选池基本面与价格特征，模拟 **{len(masters)}** 位投资大师选股框架（{data.get('version', 'v1.2')}）。"
     ]
+    if learning.get("regime"):
+        parts.append(
+            f"*在线学习：市场环境 {learning['regime']} · 修订 r{learning.get('revision', 0)}"
+            f"{(' · ' + learning['notes']['_regime']) if learning.get('notes', {}).get('_regime') else ''}*"
+        )
     for master in masters:
         picks = master.get("picks") or []
         parts.append(f"\n### {master.get('name')} · {master.get('style')}")

--- a/scripts/master_strategy_learn.py
+++ b/scripts/master_strategy_learn.py
@@ -1,0 +1,392 @@
+"""大师策略在线学习 — 每次数据更新时根据历史荐股表现与市场环境微调权重。"""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DATA_DIR = ROOT / "data"
+STATE_FILE = DATA_DIR / "master_strategy_state.json"
+HISTORY_FILE = DATA_DIR / "master_reco_history.json"
+
+BASE_VERSION = "v1.2"
+LEARNING_RATE = 0.04
+MIN_WEIGHT = 0.55
+MAX_WEIGHT = 1.55
+MIN_SAMPLES_FOR_LEARN = 3
+MAX_HISTORY = 300
+MIN_HISTORY_HOURS = 24
+
+MASTER_IDS = (
+    "buffett",
+    "graham",
+    "lynch",
+    "munger",
+    "templeton",
+    "soros",
+    "serenity",
+)
+
+DEFAULT_FACTORS: dict[str, dict[str, float]] = {
+    "buffett": {
+        "roe": 1.0,
+        "pe": 1.0,
+        "margins": 1.0,
+        "debt": 1.0,
+        "trend": 1.0,
+        "mcap": 1.0,
+    },
+    "graham": {
+        "pe": 1.0,
+        "pb": 1.0,
+        "range": 1.0,
+        "dividend": 1.0,
+        "debt": 1.0,
+    },
+    "lynch": {
+        "peg": 1.0,
+        "earnings": 1.0,
+        "revenue": 1.0,
+        "sector": 1.0,
+    },
+    "munger": {
+        "roe": 1.0,
+        "margins": 1.0,
+        "debt": 1.0,
+        "pe": 1.0,
+        "trend": 1.0,
+    },
+    "templeton": {
+        "month": 1.0,
+        "quarter": 1.0,
+        "range": 1.0,
+        "pe": 1.0,
+        "roe": 1.0,
+    },
+    "soros": {
+        "month": 1.0,
+        "rs": 1.0,
+        "trend": 1.0,
+        "volume": 1.0,
+        "beta": 1.0,
+    },
+    "serenity": {
+        "sector": 1.0,
+        "tag": 1.0,
+        "mcap": 1.0,
+        "growth": 1.0,
+        "range": 1.0,
+        "momentum": 1.0,
+    },
+}
+
+REGIME_BOOSTS: dict[str, dict[str, float]] = {
+    "risk_off": {"graham": 1.06, "templeton": 1.08, "buffett": 1.04, "soros": 0.94},
+    "risk_on": {"soros": 1.08, "lynch": 1.06, "serenity": 1.08, "graham": 0.94},
+    "neutral": {},
+}
+
+
+def _clamp_weight(val: float) -> float:
+    return round(max(MIN_WEIGHT, min(MAX_WEIGHT, val)), 3)
+
+
+def _parse_dt(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except ValueError:
+        return None
+
+
+def default_state() -> dict:
+    return {
+        "baseVersion": BASE_VERSION,
+        "revision": 0,
+        "updatedAt": None,
+        "weights": deepcopy(DEFAULT_FACTORS),
+        "performance": {mid: {"samples": 0, "winRate": None, "avgReturnPct": None} for mid in MASTER_IDS},
+        "lastUpgrade": None,
+        "upgradeNotes": {},
+        "regime": "neutral",
+    }
+
+
+def load_state() -> dict:
+    if STATE_FILE.exists():
+        try:
+            data = json.loads(STATE_FILE.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and isinstance(data.get("weights"), dict):
+                state = default_state()
+                state.update(data)
+                for mid in MASTER_IDS:
+                    state["weights"].setdefault(mid, deepcopy(DEFAULT_FACTORS[mid]))
+                    for factor, default in DEFAULT_FACTORS[mid].items():
+                        state["weights"][mid].setdefault(factor, default)
+                    state["performance"].setdefault(mid, {"samples": 0, "winRate": None, "avgReturnPct": None})
+                return state
+        except (json.JSONDecodeError, OSError):
+            pass
+    return default_state()
+
+
+def save_state(state: dict) -> None:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    STATE_FILE.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def load_master_history() -> dict:
+    if HISTORY_FILE.exists():
+        try:
+            data = json.loads(HISTORY_FILE.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and isinstance(data.get("records"), list):
+                return data
+        except (json.JSONDecodeError, OSError):
+            pass
+    return {"version": 1, "records": []}
+
+
+def master_picks_fingerprint(master_reco: dict) -> str:
+    parts = []
+    for master in master_reco.get("masters") or []:
+        for pick in master.get("picks") or []:
+            parts.append(f"{master.get('id')}:{pick.get('symbol')}:{round(pick.get('matchScore', 0))}")
+    return "|".join(sorted(parts))
+
+
+def should_append_master_history(records: list[dict], master_reco: dict, recorded_at: datetime) -> bool:
+    if not master_reco.get("masters"):
+        return False
+    if not records:
+        return True
+    last = records[-1]
+    if master_picks_fingerprint(last) != master_picks_fingerprint(master_reco):
+        return True
+    last_time = _parse_dt(last.get("recordedAt"))
+    if not last_time:
+        return True
+    current = recorded_at if recorded_at.tzinfo else recorded_at.replace(tzinfo=timezone.utc)
+    elapsed_h = (current - last_time).total_seconds() / 3600
+    return elapsed_h >= 6
+
+
+def append_master_history(master_reco: dict, recorded_at: datetime) -> dict:
+    history = load_master_history()
+    records: list[dict] = history.get("records", [])
+    compact_masters = []
+    for master in master_reco.get("masters") or []:
+        compact_masters.append(
+            {
+                "id": master.get("id"),
+                "picks": [
+                    {
+                        "symbol": p.get("symbol"),
+                        "name": p.get("name"),
+                        "price": p.get("price"),
+                        "matchScore": p.get("matchScore"),
+                        "factors": p.get("factors") or {},
+                    }
+                    for p in master.get("picks") or []
+                ],
+            }
+        )
+
+    if should_append_master_history(records, master_reco, recorded_at):
+        record = {
+            "id": recorded_at.isoformat(timespec="seconds"),
+            "recordedAt": recorded_at.isoformat(timespec="seconds"),
+            "version": master_reco.get("version"),
+            "masters": compact_masters,
+        }
+        records.append(record)
+        records = records[-MAX_HISTORY:]
+        history["records"] = records
+        history["updatedAt"] = recorded_at.isoformat(timespec="seconds")
+        history["total"] = len(records)
+        HISTORY_FILE.write_text(json.dumps(history, ensure_ascii=False, indent=2), encoding="utf-8")
+        print(f"Wrote {HISTORY_FILE} ({len(records)} records)")
+    else:
+        print("Master reco history unchanged, skip append.")
+    return history
+
+
+def _detect_regime(market: dict | None, macro: dict | None) -> str:
+    mood = (market or {}).get("summary", {}).get("mood")
+    vix = (macro or {}).get("summary", {}).get("vix")
+    if vix is not None and vix >= 22:
+        return "risk_off"
+    if mood == "偏空" or (vix is not None and vix >= 18):
+        return "risk_off"
+    if mood == "偏多":
+        return "risk_on"
+    avg = (market or {}).get("summary", {}).get("avgChangePct")
+    if avg is not None and avg > 0.5:
+        return "risk_on"
+    return "neutral"
+
+
+def _evaluate_history(quote_map: dict[str, float], now: datetime) -> tuple[dict, list[dict]]:
+    history = load_master_history()
+    perf: dict[str, list[float]] = {mid: [] for mid in MASTER_IDS}
+    learning_events: list[dict] = []
+
+    for record in history.get("records", []):
+        recorded_at = _parse_dt(record.get("recordedAt"))
+        if not recorded_at:
+            continue
+        age_h = (now - recorded_at).total_seconds() / 3600
+        if age_h < MIN_HISTORY_HOURS:
+            continue
+
+        for master in record.get("masters") or []:
+            mid = master.get("id")
+            if mid not in perf:
+                continue
+            for pick in master.get("picks") or []:
+                symbol = pick.get("symbol")
+                entry = pick.get("price")
+                current = quote_map.get(symbol)
+                if not entry or not current:
+                    continue
+                ret = round((current - entry) / entry * 100, 2)
+                perf[mid].append(ret)
+                factors = pick.get("factors") or {}
+                if factors:
+                    learning_events.append(
+                        {
+                            "masterId": mid,
+                            "symbol": symbol,
+                            "returnPct": ret,
+                            "factors": factors,
+                        }
+                    )
+
+    performance = {}
+    for mid, returns in perf.items():
+        if not returns:
+            performance[mid] = {"samples": 0, "winRate": None, "avgReturnPct": None}
+        else:
+            wins = sum(1 for r in returns if r > 0)
+            performance[mid] = {
+                "samples": len(returns),
+                "winRate": round(wins / len(returns) * 100, 1),
+                "avgReturnPct": round(sum(returns) / len(returns), 2),
+            }
+    return performance, learning_events
+
+
+def _upgrade_weights(state: dict, learning_events: list[dict], regime: str) -> tuple[dict, dict[str, str]]:
+    weights = deepcopy(state.get("weights") or default_state()["weights"])
+    notes: dict[str, str] = {}
+    changed = False
+
+    by_master: dict[str, list[dict]] = {mid: [] for mid in MASTER_IDS}
+    for event in learning_events:
+        mid = event.get("masterId")
+        if mid in by_master:
+            by_master[mid].append(event)
+
+    for mid, events in by_master.items():
+        if len(events) < MIN_SAMPLES_FOR_LEARN:
+            continue
+        factor_deltas: dict[str, list[float]] = {}
+        for event in events:
+            ret = event.get("returnPct") or 0
+            direction = 1 if ret > 0 else -1 if ret < 0 else 0
+            if direction == 0:
+                continue
+            magnitude = min(abs(ret) / 15, 1.0)
+            for factor, contribution in (event.get("factors") or {}).items():
+                if not contribution:
+                    continue
+                factor_deltas.setdefault(factor, []).append(direction * magnitude * LEARNING_RATE)
+
+        master_notes = []
+        for factor, deltas in factor_deltas.items():
+            if factor not in weights.get(mid, {}):
+                continue
+            delta = sum(deltas) / len(deltas)
+            old = weights[mid][factor]
+            new = _clamp_weight(old + delta)
+            if abs(new - old) >= 0.01:
+                weights[mid][factor] = new
+                changed = True
+                if delta > 0:
+                    master_notes.append(f"{factor}↑")
+                else:
+                    master_notes.append(f"{factor}↓")
+
+        if master_notes:
+            notes[mid] = "近期表现反馈：" + "、".join(master_notes[:4])
+
+    regime_boost = REGIME_BOOSTS.get(regime) or {}
+    if regime_boost:
+        regime_notes = []
+        for mid, boost in regime_boost.items():
+            if mid not in weights:
+                continue
+            for factor in weights[mid]:
+                old = weights[mid][factor]
+                new = _clamp_weight(old * boost)
+                if abs(new - old) >= 0.01:
+                    weights[mid][factor] = new
+                    changed = True
+            if boost != 1.0:
+                regime_notes.append(f"{mid}×{boost:.2f}")
+        if regime_notes:
+            notes["_regime"] = f"市场环境({regime})：" + "、".join(regime_notes[:5])
+
+    if changed:
+        state["weights"] = weights
+    return state, notes
+
+
+def upgrade_master_strategies(
+    quote_map: dict[str, float],
+    market: dict | None = None,
+    macro: dict | None = None,
+    now: datetime | None = None,
+) -> dict:
+    """每次站点数据更新时调用：评估历史 → 微调权重 → 持久化。"""
+    now = now or datetime.now(timezone.utc).astimezone()
+    state = load_state()
+    performance, learning_events = _evaluate_history(quote_map, now)
+    regime = _detect_regime(market, macro)
+
+    prev_weights = deepcopy(state.get("weights", {}))
+    state, notes = _upgrade_weights(state, learning_events, regime)
+
+    state["performance"] = performance
+    state["regime"] = regime
+    state["updatedAt"] = now.isoformat(timespec="seconds")
+
+    weight_changed = json.dumps(prev_weights, sort_keys=True) != json.dumps(state.get("weights"), sort_keys=True)
+    if weight_changed:
+        state["revision"] = int(state.get("revision") or 0) + 1
+        state["lastUpgrade"] = now.isoformat(timespec="seconds")
+        state["upgradeNotes"] = notes
+        print(f"Master strategy upgraded → {BASE_VERSION}.{state['revision']} ({regime})")
+    else:
+        state["upgradeNotes"] = notes or state.get("upgradeNotes") or {}
+
+    save_state(state)
+    return state
+
+
+def format_version(state: dict) -> str:
+    rev = int(state.get("revision") or 0)
+    return f"{state.get('baseVersion', BASE_VERSION)}.{rev}"
+
+
+def get_master_weights(master_id: str, state: dict | None = None) -> dict[str, float]:
+    state = state or load_state()
+    defaults = DEFAULT_FACTORS.get(master_id, {})
+    saved = (state.get("weights") or {}).get(master_id, {})
+    return {k: float(saved.get(k, v)) for k, v in defaults.items()}

--- a/scripts/strategy_masters.py
+++ b/scripts/strategy_masters.py
@@ -3,13 +3,20 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Callable
 
 import yfinance as yf
 
+from master_strategy_learn import (
+    append_master_history,
+    format_version,
+    get_master_weights,
+    upgrade_master_strategies,
+)
 from strategy_scoring import MARKET_BENCHMARKS, pct_change, sma
 
-MASTER_VERSION = "v1.1.0"
+MASTER_VERSION = "v1.2.0"
 PICKS_PER_MASTER = 2
 MIN_MATCH_SCORE = 48
 
@@ -127,6 +134,18 @@ SERENITY_SECTOR_SCORE: dict[str, float] = {
     "银行": -18,
     "潮玩零售": -12,
 }
+
+
+_ACTIVE_WEIGHTS: dict[str, float] = {}
+
+
+def _w(factor: str, base: float) -> float:
+    return round(base * _ACTIVE_WEIGHTS.get(factor, 1.0), 2)
+
+
+def _track(factors: dict[str, float], factor: str, amount: float) -> None:
+    if amount:
+        factors[factor] = round(factors.get(factor, 0) + amount, 2)
 
 
 def _norm_ratio(val: float | None, as_pct: bool = True) -> float | None:
@@ -251,108 +270,155 @@ def fetch_candidate_context(symbol: str, meta: dict) -> dict | None:
     }
 
 
-def _score_buffett(ctx: dict) -> tuple[float, list[str]]:
+def _score_buffett(ctx: dict) -> tuple[float, list[str], dict[str, float]]:
     score = 50.0
     reasons: list[str] = []
+    factors: dict[str, float] = {}
 
     roe = ctx.get("roe")
     if roe is not None:
         if roe >= 20:
-            score += 18
+            pts = _w("roe", 18)
+            score += pts
+            _track(factors, "roe", pts)
             reasons.append(f"ROE {roe}% — 资本回报优秀，符合巴菲特护城河标准")
         elif roe >= 12:
-            score += 10
+            pts = _w("roe", 10)
+            score += pts
+            _track(factors, "roe", pts)
             reasons.append(f"ROE {roe}% — 盈利能力稳健")
         else:
-            score -= 8
+            pts = _w("roe", -8)
+            score += pts
+            _track(factors, "roe", pts)
 
     pe = ctx.get("pe")
     if pe is not None:
         if pe <= 25:
-            score += 12
+            pts = _w("pe", 12)
+            score += pts
+            _track(factors, "pe", pts)
             reasons.append(f"PE {pe} — 估值在能力圈合理区间")
         elif pe <= 35:
-            score += 4
+            pts = _w("pe", 4)
+            score += pts
+            _track(factors, "pe", pts)
         else:
-            score -= 10
+            pts = _w("pe", -10)
+            score += pts
+            _track(factors, "pe", pts)
             reasons.append(f"PE {pe} 偏高 — 需更大安全边际才符合巴菲特买价")
 
     margins = ctx.get("profitMargins")
     if margins is not None and margins >= 15:
-        score += 8
+        pts = _w("margins", 8)
+        score += pts
+        _track(factors, "margins", pts)
         reasons.append(f"净利率 {margins}% — 业务具备定价权")
 
     debt = ctx.get("debtToEquity")
     if debt is not None:
         if debt < 80:
-            score += 6
+            pts = _w("debt", 6)
+            score += pts
+            _track(factors, "debt", pts)
             reasons.append("负债率可控，财务风险较低")
         elif debt > 150:
-            score -= 8
+            pts = _w("debt", -8)
+            score += pts
+            _track(factors, "debt", pts)
 
     if ctx.get("aboveMa200") is True and ctx.get("rangePosition", 1) < 0.75:
-        score += 8
+        pts = _w("trend", 8)
+        score += pts
+        _track(factors, "trend", pts)
         reasons.append("长期趋势向上且未严重高估 — 可分批建仓")
     elif ctx.get("rangePosition", 1) < 0.35:
-        score += 10
+        pts = _w("trend", 10)
+        score += pts
+        _track(factors, "trend", pts)
         reasons.append("价格接近 52 周低位 — 优质资产回调机会")
 
     mcap = ctx.get("marketCap")
     if mcap and mcap >= 50e9:
-        score += 4
+        pts = _w("mcap", 4)
+        score += pts
+        _track(factors, "mcap", pts)
         reasons.append("龙头体量，业务护城河更易验证")
 
-    return _clamp_score(score), reasons[:4]
+    return _clamp_score(score), reasons[:4], factors
 
 
-def _score_graham(ctx: dict) -> tuple[float, list[str]]:
+def _score_graham(ctx: dict) -> tuple[float, list[str], dict[str, float]]:
     score = 45.0
     reasons: list[str] = []
+    factors: dict[str, float] = {}
 
     pe = ctx.get("pe")
     if pe is not None:
         if pe < 12:
-            score += 22
+            pts = _w("pe", 22)
+            score += pts
+            _track(factors, "pe", pts)
             reasons.append(f"PE {pe} — 深度价值区间，安全边际充足")
         elif pe < 18:
-            score += 12
+            pts = _w("pe", 12)
+            score += pts
+            _track(factors, "pe", pts)
             reasons.append(f"PE {pe} — 低于市场平均，具备安全边际")
         elif pe > 30:
-            score -= 15
+            pts = _w("pe", -15)
+            score += pts
+            _track(factors, "pe", pts)
 
     pb = ctx.get("pb")
     if pb is not None:
         if pb < 1.2:
-            score += 18
+            pts = _w("pb", 18)
+            score += pts
+            _track(factors, "pb", pts)
             reasons.append(f"PB {pb} — 资产折价，经典格雷厄姆信号")
         elif pb < 2:
-            score += 8
+            pts = _w("pb", 8)
+            score += pts
+            _track(factors, "pb", pts)
         elif pb > 5:
-            score -= 8
+            pts = _w("pb", -8)
+            score += pts
+            _track(factors, "pb", pts)
 
     rp = ctx.get("rangePosition")
     if rp is not None and rp < 0.3:
-        score += 12
+        pts = _w("range", 12)
+        score += pts
+        _track(factors, "range", pts)
         reasons.append("价格处于 52 周区间下沿 — 悲观定价带来安全边际")
     elif rp is not None and rp < 0.5:
-        score += 6
+        pts = _w("range", 6)
+        score += pts
+        _track(factors, "range", pts)
 
     div = ctx.get("dividendYield")
     if div is not None and div >= 2:
-        score += 5
+        pts = _w("dividend", 5)
+        score += pts
+        _track(factors, "dividend", pts)
         reasons.append(f"股息率 {div}% — 提供下行保护垫")
 
     debt = ctx.get("debtToEquity")
     if debt is not None and debt > 200:
-        score -= 10
+        pts = _w("debt", -10)
+        score += pts
+        _track(factors, "debt", pts)
         reasons.append("负债过高 — 不符合格雷厄姆防御型标准")
 
-    return _clamp_score(score), reasons[:4]
+    return _clamp_score(score), reasons[:4], factors
 
 
-def _score_lynch(ctx: dict) -> tuple[float, list[str]]:
+def _score_lynch(ctx: dict) -> tuple[float, list[str], dict[str, float]]:
     score = 48.0
     reasons: list[str] = []
+    factors: dict[str, float] = {}
 
     peg = ctx.get("peg")
     earn_g = ctx.get("earningsGrowth")
@@ -361,124 +427,181 @@ def _score_lynch(ctx: dict) -> tuple[float, list[str]]:
 
     if peg is not None:
         if peg < 1:
-            score += 22
+            pts = _w("peg", 22)
+            score += pts
+            _track(factors, "peg", pts)
             reasons.append(f"PEG {peg} — 成长相对估值便宜，林奇「十倍股」潜力")
         elif peg < 1.5:
-            score += 14
+            pts = _w("peg", 14)
+            score += pts
+            _track(factors, "peg", pts)
             reasons.append(f"PEG {peg} — 成长合理价，符合 GARP 框架")
         elif peg > 2.5:
-            score -= 10
+            pts = _w("peg", -10)
+            score += pts
+            _track(factors, "peg", pts)
 
     if earn_g is not None:
         if earn_g >= 20:
-            score += 12
+            pts = _w("earnings", 12)
+            score += pts
+            _track(factors, "earnings", pts)
             reasons.append(f"盈利增速 {earn_g}% — 成长故事可验证")
         elif earn_g >= 10:
-            score += 6
+            pts = _w("earnings", 6)
+            score += pts
+            _track(factors, "earnings", pts)
         elif earn_g < 0:
-            score -= 12
+            pts = _w("earnings", -12)
+            score += pts
+            _track(factors, "earnings", pts)
 
     if rev_g is not None and rev_g >= 10:
-        score += 6
+        pts = _w("revenue", 6)
+        score += pts
+        _track(factors, "revenue", pts)
         reasons.append(f"营收增速 {rev_g}% — 业务扩张持续")
 
     if pe is not None and pe < 35 and earn_g and earn_g > 15:
-        score += 4
+        pts = _w("earnings", 4)
+        score += pts
+        _track(factors, "earnings", pts)
 
     sector = ctx.get("sector") or ""
     if sector in ("半导体", "新能源", "互联网", "软件云计算", "电商云计算"):
-        score += 4
+        pts = _w("sector", 4)
+        score += pts
+        _track(factors, "sector", pts)
         reasons.append(f"{sector} — 林奇偏好的可理解成长行业")
 
-    return _clamp_score(score), reasons[:4]
+    return _clamp_score(score), reasons[:4], factors
 
 
-def _score_munger(ctx: dict) -> tuple[float, list[str]]:
+def _score_munger(ctx: dict) -> tuple[float, list[str], dict[str, float]]:
     score = 50.0
     reasons: list[str] = []
+    factors: dict[str, float] = {}
 
     roe = ctx.get("roe")
     if roe is not None:
         if roe >= 25:
-            score += 20
+            pts = _w("roe", 20)
+            score += pts
+            _track(factors, "roe", pts)
             reasons.append(f"ROE {roe}% — 优质复利机器，芒格会长期持有")
         elif roe >= 18:
-            score += 12
+            pts = _w("roe", 12)
+            score += pts
+            _track(factors, "roe", pts)
         else:
-            score -= 6
+            pts = _w("roe", -6)
+            score += pts
+            _track(factors, "roe", pts)
 
     margins = ctx.get("profitMargins")
     if margins is not None and margins >= 25:
-        score += 14
+        pts = _w("margins", 14)
+        score += pts
+        _track(factors, "margins", pts)
         reasons.append(f"净利率 {margins}% — 轻资产高毛利特征")
     elif margins is not None and margins >= 15:
-        score += 6
+        pts = _w("margins", 6)
+        score += pts
+        _track(factors, "margins", pts)
 
     debt = ctx.get("debtToEquity")
     if debt is not None and debt < 60:
-        score += 8
+        pts = _w("debt", 8)
+        score += pts
+        _track(factors, "debt", pts)
         reasons.append("低杠杆 — 符合芒格「避免愚蠢」原则")
 
     pe = ctx.get("pe")
     if pe is not None and roe and roe >= 20:
         if pe <= 40:
-            score += 8
+            pts = _w("pe", 8)
+            score += pts
+            _track(factors, "pe", pts)
             reasons.append("优质公司合理溢价可接受 — 以合理价格买伟大公司")
         else:
-            score -= 4
+            pts = _w("pe", -4)
+            score += pts
+            _track(factors, "pe", pts)
 
     if ctx.get("aboveMa200") is True:
-        score += 6
+        pts = _w("trend", 6)
+        score += pts
+        _track(factors, "trend", pts)
         reasons.append("长期趋势完好 — 复利故事未被破坏")
 
-    return _clamp_score(score), reasons[:4]
+    return _clamp_score(score), reasons[:4], factors
 
 
-def _score_templeton(ctx: dict) -> tuple[float, list[str]]:
+def _score_templeton(ctx: dict) -> tuple[float, list[str], dict[str, float]]:
     score = 42.0
     reasons: list[str] = []
+    factors: dict[str, float] = {}
 
     month = ctx.get("monthChangePct")
     quarter = ctx.get("quarterChangePct")
     rp = ctx.get("rangePosition")
 
     if month is not None and month < -8:
-        score += 16
+        pts = _w("month", 16)
+        score += pts
+        _track(factors, "month", pts)
         reasons.append(f"近一月 {month}% — 市场悲观，邓普顿式逆向机会")
     elif month is not None and month < -3:
-        score += 8
+        pts = _w("month", 8)
+        score += pts
+        _track(factors, "month", pts)
     elif month is not None and month > 15:
-        score -= 10
+        pts = _w("month", -10)
+        score += pts
+        _track(factors, "month", pts)
 
     if quarter is not None and quarter < -15:
-        score += 10
+        pts = _w("quarter", 10)
+        score += pts
+        _track(factors, "quarter", pts)
         reasons.append(f"近三月 {quarter}% — 深度回调，关注基本面是否错杀")
 
     if rp is not None and rp < 0.25:
-        score += 14
+        pts = _w("range", 14)
+        score += pts
+        _track(factors, "range", pts)
         reasons.append("价格接近 52 周底部 — 「极度悲观时买入」")
     elif rp is not None and rp < 0.4:
-        score += 8
+        pts = _w("range", 8)
+        score += pts
+        _track(factors, "range", pts)
 
     pe = ctx.get("pe")
     if pe is not None and pe < 25:
-        score += 8
+        pts = _w("pe", 8)
+        score += pts
+        _track(factors, "pe", pts)
         reasons.append(f"PE {pe} — 悲观中仍有估值支撑")
     elif pe is not None and pe > 50:
-        score -= 8
+        pts = _w("pe", -8)
+        score += pts
+        _track(factors, "pe", pts)
         reasons.append("估值仍高 — 可能只是成长回落而非错杀")
 
     roe = ctx.get("roe")
     if roe is not None and roe >= 12:
-        score += 6
+        pts = _w("roe", 6)
+        score += pts
+        _track(factors, "roe", pts)
         reasons.append("盈利能力仍在 — 逆向不是接飞刀")
 
-    return _clamp_score(score), reasons[:4]
+    return _clamp_score(score), reasons[:4], factors
 
 
-def _score_soros(ctx: dict) -> tuple[float, list[str]]:
+def _score_soros(ctx: dict) -> tuple[float, list[str], dict[str, float]]:
     score = 45.0
     reasons: list[str] = []
+    factors: dict[str, float] = {}
 
     month = ctx.get("monthChangePct")
     rs = ctx.get("relativeStrength")
@@ -486,49 +609,70 @@ def _score_soros(ctx: dict) -> tuple[float, list[str]]:
 
     if month is not None:
         if month >= 8:
-            score += 16
+            pts = _w("month", 16)
+            score += pts
+            _track(factors, "month", pts)
             reasons.append(f"近一月 +{month}% — 趋势强劲，反身性正反馈")
         elif month >= 3:
-            score += 10
+            pts = _w("month", 10)
+            score += pts
+            _track(factors, "month", pts)
         elif month < -5:
-            score -= 6
+            pts = _w("month", -6)
+            score += pts
+            _track(factors, "month", pts)
 
     if rs is not None:
         if rs >= 5:
-            score += 14
+            pts = _w("rs", 14)
+            score += pts
+            _track(factors, "rs", pts)
             reasons.append(f"相对强度 +{rs}% — 跑赢大盘，宏观共振")
         elif rs >= 2:
-            score += 8
+            pts = _w("rs", 8)
+            score += pts
+            _track(factors, "rs", pts)
         elif rs < -5:
-            score -= 8
+            pts = _w("rs", -8)
+            score += pts
+            _track(factors, "rs", pts)
 
     if ctx.get("aboveMa50") is True and ctx.get("aboveMa200") is True:
-        score += 10
+        pts = _w("trend", 10)
+        score += pts
+        _track(factors, "trend", pts)
         reasons.append("均线多头排列 — 趋势交易确认")
 
     if vol is not None and vol >= 1.3:
-        score += 6
+        pts = _w("volume", 6)
+        score += pts
+        _track(factors, "volume", pts)
         reasons.append(f"量比 {vol} — 资金参与度高")
 
     beta = ctx.get("beta")
     if beta is not None and beta >= 1.1 and month and month > 0:
-        score += 4
+        pts = _w("beta", 4)
+        score += pts
+        _track(factors, "beta", pts)
         reasons.append("高 Beta 放大趋势 — 索罗斯式进攻配置")
 
-    return _clamp_score(score), reasons[:4]
+    return _clamp_score(score), reasons[:4], factors
 
 
-def _score_serenity(ctx: dict) -> tuple[float, list[str]]:
+def _score_serenity(ctx: dict) -> tuple[float, list[str], dict[str, float]]:
     """X @aleabitoreddit — 卡脖子投资法 / Bottleneck Hunter。"""
     score = 38.0
     reasons: list[str] = []
+    factors: dict[str, float] = {}
     symbol = ctx.get("symbol", "")
 
     tag = SERENITY_BOTTLENECK_TAGS.get(symbol)
     sector = ctx.get("sector") or (tag[0] if tag else "")
     sector_bonus = SERENITY_SECTOR_SCORE.get(sector, 0)
     if sector_bonus:
-        score += sector_bonus
+        pts = _w("sector", sector_bonus)
+        score += pts
+        _track(factors, "sector", pts)
         if sector_bonus > 0:
             reasons.append(f"{sector} — AI/机器人供应链瓶颈相关环节")
         else:
@@ -537,73 +681,107 @@ def _score_serenity(ctx: dict) -> tuple[float, list[str]]:
     if tag:
         layer, note = tag
         if "非瓶颈" in note or "降权" in note or "终端龙头" in note:
-            score -= 12
+            pts = _w("tag", -12)
+            score += pts
+            _track(factors, "tag", pts)
             reasons.append(f"{layer}：{note}")
         else:
-            score += 14
+            pts = _w("tag", 14)
+            score += pts
+            _track(factors, "tag", pts)
             reasons.append(f"紫苏叶环节 · {layer} — {note}")
 
     mcap = ctx.get("marketCap")
     if mcap is not None:
         if mcap < 30e9:
-            score += 16
+            pts = _w("mcap", 16)
+            score += pts
+            _track(factors, "mcap", pts)
             reasons.append("小市值 — 机构覆盖不足、重估弹性大")
         elif mcap < 100e9:
-            score += 10
+            pts = _w("mcap", 10)
+            score += pts
+            _track(factors, "mcap", pts)
             reasons.append("中市值 — 仍处价格发现窗口")
         elif mcap < 300e9:
-            score += 2
+            pts = _w("mcap", 2)
+            score += pts
+            _track(factors, "mcap", pts)
         elif mcap > 1e12:
-            score -= 22
+            pts = _w("mcap", -22)
+            score += pts
+            _track(factors, "mcap", pts)
             reasons.append("超大盘龙头 — 「买瓶颈不买品牌」框架下降权")
         elif mcap > 400e9:
-            score -= 14
+            pts = _w("mcap", -14)
+            score += pts
+            _track(factors, "mcap", pts)
             reasons.append("大盘蓝筹 — 非典型卡脖子小盘标的")
 
     earn_g = ctx.get("earningsGrowth")
     rev_g = ctx.get("revenueGrowth")
     if earn_g is not None and earn_g >= 15:
-        score += 10
+        pts = _w("growth", 10)
+        score += pts
+        _track(factors, "growth", pts)
         reasons.append(f"盈利增速 {earn_g}% — 瓶颈环节需求释放")
     elif earn_g is not None and earn_g >= 5:
-        score += 4
+        pts = _w("growth", 4)
+        score += pts
+        _track(factors, "growth", pts)
     if rev_g is not None and rev_g >= 10:
-        score += 6
+        pts = _w("growth", 6)
+        score += pts
+        _track(factors, "growth", pts)
 
     rp = ctx.get("rangePosition")
     if rp is not None and rp < 0.45:
-        score += 10
+        pts = _w("range", 10)
+        score += pts
+        _track(factors, "range", pts)
         reasons.append("52 周区间偏低 — 或在机构大规模覆盖前")
     elif rp is not None and rp > 0.85:
-        score -= 8
+        pts = _w("range", -8)
+        score += pts
+        _track(factors, "range", pts)
         reasons.append("接近日内/年内高位 — 警惕情绪末段追价")
 
     month = ctx.get("monthChangePct")
     if month is not None:
         if 0 < month <= 18:
-            score += 6
+            pts = _w("momentum", 6)
+            score += pts
+            _track(factors, "momentum", pts)
             reasons.append(f"近一月 +{month}% — 重估进行中但未必过热")
         elif month > 35:
-            score -= 10
+            pts = _w("momentum", -10)
+            score += pts
+            _track(factors, "momentum", pts)
             reasons.append("短期涨幅过大 — 社交情绪驱动后慎追")
 
     rs = ctx.get("relativeStrength")
     if rs is not None and rs >= 3:
-        score += 6
+        pts = _w("momentum", 6)
+        score += pts
+        _track(factors, "momentum", pts)
 
     beta = ctx.get("beta")
     if beta is not None and beta >= 1.15:
-        score += 4
+        pts = _w("momentum", 4)
+        score += pts
+        _track(factors, "momentum", pts)
 
     margins = ctx.get("profitMargins")
     if margins is not None and margins >= 20:
-        score += 5
+        pts = _w("growth", 5)
+        score += pts
+        _track(factors, "growth", pts)
         reasons.append(f"净利率 {margins}% — 环节稀缺性/定价权")
 
-    return _clamp_score(score), reasons[:5]
+    return _clamp_score(score), reasons[:5], factors
 
 
-SCORERS: dict[str, Callable[[dict], tuple[float, list[str]]]] = {
+SCORERS: dict[str, Callable[[dict], tuple[float, list[str], dict[str, float]]]] = {
     "buffett": _score_buffett,
     "graham": _score_graham,
     "lynch": _score_lynch,
@@ -667,7 +845,7 @@ def _build_plan(profile: MasterProfile, ctx: dict, score: float) -> dict:
     return {"entry": entry, "holding": holding, "risk": risk, "position": position}
 
 
-def _pick_row(profile: MasterProfile, ctx: dict, score: float, reasons: list[str]) -> dict:
+def _pick_row(profile: MasterProfile, ctx: dict, score: float, reasons: list[str], factors: dict[str, float]) -> dict:
     signal, label = _signal_from_score(score)
     metrics = {
         "pe": ctx.get("pe"),
@@ -699,6 +877,7 @@ def _pick_row(profile: MasterProfile, ctx: dict, score: float, reasons: list[str
         "signal": signal,
         "signalLabel": label,
         "reasons": reasons,
+        "factors": factors,
         "plan": _build_plan(profile, ctx, score),
         "metrics": metrics,
     }
@@ -715,7 +894,18 @@ def _master_extra(profile: MasterProfile) -> dict:
     return {}
 
 
-def build_master_recommendations(candidates: dict) -> dict:
+def build_master_recommendations(
+    candidates: dict,
+    quote_map: dict[str, float] | None = None,
+    market: dict | None = None,
+    macro: dict | None = None,
+    now: datetime | None = None,
+) -> dict:
+    global _ACTIVE_WEIGHTS
+
+    state = upgrade_master_strategies(quote_map or {}, market, macro, now)
+    version = format_version(state)
+
     contexts: list[dict] = []
     for symbol, meta in candidates.items():
         ctx = fetch_candidate_context(symbol, meta)
@@ -723,16 +913,34 @@ def build_master_recommendations(candidates: dict) -> dict:
             contexts.append(ctx)
 
     masters_out = []
+    upgrade_notes = state.get("upgradeNotes") or {}
+    performance = state.get("performance") or {}
+
     for profile in MASTER_PROFILES:
+        _ACTIVE_WEIGHTS = get_master_weights(profile.id, state)
         scorer = SCORERS[profile.id]
-        ranked: list[tuple[float, dict, list[str]]] = []
+        ranked: list[tuple[float, dict, list[str], dict[str, float]]] = []
         for ctx in contexts:
-            score, reasons = scorer(ctx)
+            score, reasons, factors = scorer(ctx)
             if score >= MIN_MATCH_SCORE:
-                ranked.append((score, ctx, reasons))
+                ranked.append((score, ctx, reasons, factors))
         ranked.sort(key=lambda x: (-x[0], x[1]["symbol"]))
 
-        picks = [_pick_row(profile, ctx, score, reasons) for score, ctx, reasons in ranked[:PICKS_PER_MASTER]]
+        picks = [
+            _pick_row(profile, ctx, score, reasons, factors)
+            for score, ctx, reasons, factors in ranked[:PICKS_PER_MASTER]
+        ]
+
+        perf = performance.get(profile.id) or {}
+        learning = {
+            "revision": state.get("revision"),
+            "regime": state.get("regime"),
+            "samples": perf.get("samples"),
+            "winRate": perf.get("winRate"),
+            "avgReturnPct": perf.get("avgReturnPct"),
+            "upgradeNote": upgrade_notes.get(profile.id),
+            "lastUpgrade": state.get("lastUpgrade"),
+        }
 
         masters_out.append(
             {
@@ -744,21 +952,35 @@ def build_master_recommendations(candidates: dict) -> dict:
                 "principles": list(profile.principles),
                 "holdingHorizon": profile.holding,
                 "picks": picks,
+                "learning": learning,
                 **_master_extra(profile),
             }
         )
 
-    return {
-        "version": MASTER_VERSION,
+    result = {
+        "version": version,
         "strategy": (
-            f"{MASTER_VERSION} 投资大师风格荐股："
-            f"基于 Yahoo 基本面与价格特征，模拟 {len(MASTER_PROFILES)} 位大师选股逻辑；"
-            f"每位大师推荐 {PICKS_PER_MASTER} 只，与战术 v1.3 相互独立。"
+            f"{version} 投资大师风格荐股（在线学习）："
+            f"每次数据更新根据历史荐股表现与市场环境微调 {len(MASTER_PROFILES)} 位大师因子权重；"
+            f"当前市场环境 {state.get('regime', 'neutral')}。"
         ),
         "disclaimer": (
             "大师风格荐股为规则化模拟，非真实人物操作建议；"
+            "权重学习基于历史快照与公开行情，样本不足时变化极小；"
             "Serenity 相关内容为对其公开框架的量化近似，勿当作 X 账号买卖信号；"
-            "基本面数据可能有延迟或缺失，仅供研究，不构成投资建议。"
+            "仅供研究，不构成投资建议。"
         ),
+        "learning": {
+            "revision": state.get("revision"),
+            "regime": state.get("regime"),
+            "updatedAt": state.get("updatedAt"),
+            "lastUpgrade": state.get("lastUpgrade"),
+            "notes": upgrade_notes,
+        },
         "masters": masters_out,
     }
+
+    if now:
+        append_master_history(result, now)
+
+    return result


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

每次 CI 跑 `fetch_data.py` 时，自动对七位大师策略进行**在线学习**与权重升级。

## 机制

1. **记录历史** — `data/master_reco_history.json` 保存每次大师荐股快照（含因子贡献）
2. **评估表现** — 对比 24h+ 历史荐股与当前价格，计算胜率/均收益
3. **微调权重** — 表现好的因子权重↑，差的因子↓（学习率 4%，范围 0.55–1.55）
4. **环境适配** — 根据 VIX/市场情绪（risk_on / risk_off / neutral）调整大师偏好
5. **版本递增** — `v1.2.{revision}` 每次权重显著变化时 +1

## 前端

投资大师 Tab 展示：策略版本、市场环境、各大师学习反馈（样本/胜率/升级说明）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62fa50dd-4422-4777-aa97-3de214aa93a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62fa50dd-4422-4777-aa97-3de214aa93a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

